### PR TITLE
Add drawdown plot

### DIFF
--- a/src/market_analy/analysis.py
+++ b/src/market_analy/analysis.py
@@ -457,7 +457,7 @@ class Base(metaclass=ABCMeta):
         ----------
         **kwargs
             Parameters to define period / price data to be analysed. See
-            method doc with `help(analysis.__doc__)`. Cannot include
+            module doc with `help(analysis.__doc__)`. Cannot include
             'close_only' or 'interval'.
         """
         return self._daily_prices(close_only=False, **kwargs)
@@ -471,7 +471,7 @@ class Base(metaclass=ABCMeta):
         ----------
         **kwargs
             Parameters to define period / price data to be analysed. See
-            method doc with `help(analysis.__doc__)`. Cannot include
+            module doc with `help(analysis.__doc__)`. Cannot include
             'close_only' or 'interval'.
         """
         return self._daily_prices(close_only=True, **kwargs)
@@ -483,7 +483,7 @@ class Base(metaclass=ABCMeta):
         ----------
         **kwargs
             Parameters to define period / price data to be analysed. See
-            method doc with `help(analysis.__doc__)`. Cannot include
+            module doc with `help(analysis.__doc__)`. Cannot include
             'interval', 'add_a_row', 'close_only' or 'lose_single_symbol'
         """
         interval = "1D" if request_daily_prices(**kwargs) else None
@@ -510,7 +510,7 @@ class Base(metaclass=ABCMeta):
         ----------
         **kwargs
             Parameters to define period / price data to be analysed. See
-            method doc with `help(analysis.__doc__)`. Cannot include
+            module doc with `help(analysis.__doc__)`. Cannot include
             'interval', 'add_a_row', 'close_only' or 'lose_single_symbol'.
         """
         interval = "1D" if request_daily_prices(**kwargs) else None
@@ -543,7 +543,7 @@ class Base(metaclass=ABCMeta):
         periods
             List of dictionaries with each dictionary defining a period
             over which require pct change. Period defined with period
-            parameters. See method doc with `help(analysis.__doc__)`.
+            parameters. See module doc with `help(analysis.__doc__)`.
             Cannot include 'interval', 'add_a_row', 'close_only' or
             'lose_single_symbol'.
         """
@@ -569,7 +569,7 @@ class Base(metaclass=ABCMeta):
         ----------
         **kwargs
             Parameters to define period / price data to be analysed. See
-            method doc with `help(analysis.__doc__)`. Cannot include
+            module doc with `help(analysis.__doc__)`. Cannot include
             'interval', 'add_a_row', 'close_only' or 'lose_single_symbol'.
         """
         interval = "1D" if request_daily_prices(**kwargs) else None
@@ -622,7 +622,7 @@ class Base(metaclass=ABCMeta):
 
         **kwargs
             Parameters to define period / price data to be analysed. See
-            method doc with `help(analysis.__doc__)`. Cannot include
+            module doc with `help(analysis.__doc__)`. Cannot include
             'add_a_row' or 'close_only'.
 
         _display

--- a/src/market_analy/charts.py
+++ b/src/market_analy/charts.py
@@ -1604,21 +1604,10 @@ class BaseSubsetDD(Base):
             return
 
         if data is not None:
-            # TODO CAN LOSE THIS IF ALL WORKING AS REQUIRED
-            # NOTE SEE note further below re keeping this until happy
-            # # x_changed has to be resolved here before setting any new data
-            # if isinstance(data.index, pd.DatetimeIndex):
-            #     x_changed = not self.data.index.left.equals(data.index)
-            # else:
-            #     x_changed = not self.data.index.equals(data.index)
             self.data = data
             if not self._update_mark_data_attr_to_reflect_plotted:
                 self.mark.x = self._x_data
                 self.mark.y = self._get_mark_y_data()
-        # TODO CAN LOSE THIS IF ALL WORKING AS REQUIRED
-        # NOTE SEE note further below re keeping this until happy
-        # else:
-        #     x_changed = False
 
         if data_y2 is not None:
             assert self._has_y2_plot
@@ -1651,28 +1640,6 @@ class BaseSubsetDD(Base):
         if prior_plotted_x_ticks.equals(self.plotted_x_ticks):
             # trigger handler manually as will not have fired if value unchanged
             self._x_domain_chg_handler(event=None)
-
-        # TODO DEL IF GET A NEW APPROACH WORKING...
-        # NOTE TO NOT BE TOO HASTY LOSING THIS!!! AS OF 12/09/24 BELIEVE THAT THERE IS
-        # A FLAKY BUG WITH THE SUGGESTED IMPLENTATION...Keep playing with it and doen't
-        # lose this code (or that above) until happy
-        # no_plot = self.plotted_x_ticks.empty
-        # if no_plot or x_changed:
-        #     # mark attributes will be updated to reflect plotted
-        #     # and presentation will be updated all as part of setting
-        #     # plotted_x_ticks implementation (via self._x_domain_chg_handler)
-        #     plot_interval = self._get_plot_interval(visible_x_ticks)
-        #     if plot_interval.length < self.tick_interval:
-        #         subset = self.date_intervals_subset(plot_interval, overlap=True)
-        #         plot_interval = upd.interval_of_intervals(subset, closed="left")
-        #     self.plotted_x_ticks = plot_interval
-        # else:
-        #     # if only y changed
-        #     if self._update_mark_data_attr_to_reflect_plotted:
-        #         self._set_mark_to_plotted()
-        #     if self._has_y2_plot and self._update_mark_y2_data_attr_to_reflect_plotted:
-        #         self._set_mark_y2_to_plotted()
-        #     self.update_presentation()
 
     def update(
         self,

--- a/src/market_analy/gui_parts.py
+++ b/src/market_analy/gui_parts.py
@@ -113,7 +113,7 @@ class IntervalSelector(wu.ToggleButtonsHandled):
             Passed to `w.Layout` assigned to `ToggleButtons`.
         """
         values = [intervals.to_ptinterval(lab) for lab in labels]
-        tooltips = ["Select date interval" for _ in range(len(values))]
+        tooltips = ["Select tick interval" for _ in range(len(values))]
         super().__init__(
             labels,
             values,

--- a/src/market_analy/guis.py
+++ b/src/market_analy/guis.py
@@ -974,7 +974,11 @@ class BasePrice(BaseVariableDates):
         try:
             self.set_drawdown_period(window)
         except ValueError as err:
-            self._popup("Drawdown period unavailable", err.args[0])
+            if window == "365D" and self._interval_selector.value != ONE_DAY:
+                msg = "52wk drawdown period only available with '1D' tick interval"
+            else:
+                msg = err.args[0]
+            self._popup("Drawdown period unavailable", msg)
             change["owner"].set_value_unobserved(old)
 
     def _create_drawdown_slctr(self) -> gui_parts.DrawdownSelector:
@@ -1433,6 +1437,8 @@ class BasePrice(BaseVariableDates):
         self._update_chart(data, data2, prices, visible_x_ticks=vxts, reset_slider=True)
         if self._HAS_INTERVAL_SELECTOR:
             self._interval_selector.set_value_unobserved(self._tick_interval)
+        if self._HAS_DRAWDOWN:
+            self._drawdown_selector.set_value_unobserved("ATH")
 
     def _reset(self):
         self.slctr.disable()

--- a/src/market_analy/guis.py
+++ b/src/market_analy/guis.py
@@ -11,19 +11,19 @@ DateSliderMixin():
 BasePrice(Base):
     Base implementation for GUIs incorporating a price chart.
 
-ChartLine(Base):
+GuiLine(Base):
     Line price chart GUI for single financial instrument.
 
-ChartMultLine(Base):
+GuiMultLine(Base):
     Line price chart GUI for comparing multiple financial instruments.
 
-ChartOHLC(Base):
+GuiOHLC(Base):
     OHLC chart GUI for single financial instrument.
 
-PctChg(Base, DateSliderMixin):
+GuiPctChg(Base, DateSliderMixin):
     Bar chart GUI of precentage changes of single instrument.
 
-PctChgMult(PctChg):
+GuiPctChgMult(PctChg):
     Bar chart GUI of precentage changes of multiple instruments.
 
 Notes

--- a/src/market_analy/guis.py
+++ b/src/market_analy/guis.py
@@ -1439,6 +1439,7 @@ class BasePrice(BaseVariableDates):
             self._interval_selector.set_value_unobserved(self._tick_interval)
         if self._HAS_DRAWDOWN:
             self._drawdown_selector.set_value_unobserved("ATH")
+            self.chart.show_y2()
 
     def _reset(self):
         self.slctr.disable()

--- a/src/market_analy/standalone.py
+++ b/src/market_analy/standalone.py
@@ -1,5 +1,10 @@
 """Standalone analysis functions."""
 
+from __future__ import annotations
+
+import datetime
+from typing import Union
+
 import pandas as pd
 import valimp
 
@@ -93,3 +98,151 @@ def net_of(data: pd.DataFrame, rebase: bool = True) -> pd.DataFrame:
     }
 
     return pd.DataFrame({col: mapping[col] for col in df.columns})
+
+
+def get_ath(data: Union[pd.Series, pd.DataFrame]) -> Union[pd.Series, pd.DataFrame]:
+    """Return all-time high as at each timestamp.
+
+    Returns ATH as at end of period represented by corresponding
+    timestamp.
+
+    NB: ATH assumed as high since start of `data`.
+
+    Parameters
+    ----------
+    data
+        If pd.Series then values as high during the period represented
+        by the corresponding indice.
+
+        DataFrame must include "high" column(s) with values as
+        described for a pd.Series. If DataFrame covers multiple
+        symbols then columns should be indexed with a `pd.MultiIndex`
+        with level 0 as symbol.
+    """
+    if isinstance(data, pd.Series):
+        return data.expanding().max()
+    df = data[[c for c in data.columns if "high" in c]]
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.droplevel(1)
+    return df.expanding().max()
+
+
+@valimp.parse
+def get_period_high(
+    data: Union[pd.Series, pd.DataFrame],
+    window: Union[int, str, datetime.timedelta],
+    include_current: bool = True,
+) -> Union[pd.Series, pd.DataFrame]:
+    """Return 52wk high as at each timestamp.
+
+    NB: For sessions within the first 52 weeks of data, the high will
+    represent the high of prices since the start of the data.
+
+    Parameters
+    ----------
+    data
+        If pd.Series then values as high during the period represented
+        by the corresponding indice.
+
+        If pd.DataFrame then must include "high" column(s) with values
+        as described for a pd.Series. If DataFrame covers multiple
+        symbols then columns should be indexed with a `pd.MultiIndex`
+        with level 0 as symbol.
+
+    window
+        Value to be passed to 'window` parameter of
+        `pd.DataFrame.rolling` (or `pd.Series.rolling`) to determine
+        period over which highs shoudl be evaluated. Can be passed as:
+            `str` of a pandas frequency representing period over
+            which to evaluate highs, for example "365D" for '52wk'
+            highs.
+
+            `int` to define window as a fixed number of observations,
+            for example every 3 values.
+
+            `datetime.timedelta` to define window as a fixed period.
+
+    include_current : bool
+        Determines if the evaluation of the high should include the
+        timestamp that represents the end of the period.
+    """
+    closed = "right" if include_current else "left"
+    if isinstance(data, pd.Series):
+        rolling = data.rolling(
+            window, min_periods=1, center=False, win_type=None, closed=closed
+        )
+        return rolling.max()
+
+    df = data[[c for c in data.columns if "high" in c]]
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.droplevel(1)
+
+    rolling = df.rolling(
+        window, min_periods=1, center=False, win_type=None, closed=closed
+    )
+    return rolling.max()
+
+
+@valimp.parse
+def get_pct_off_high(
+    data: pd.DataFrame,
+    window: Union[int, str, datetime.timedelta, None],
+    include_current: bool = True,
+) -> pd.DataFrame:
+    """Return percent off high as at each timestamp.
+
+    NB: For timestamps within the first period the return will be
+    the percentage off the high as of that timestamp (i.e. the high
+    will have been evaluated over shorter period than `pdfreq`)
+
+    Parameters
+    ----------
+    data
+        pd.DataFrame with "high" column(s) with values as the high of
+        the period represented by the corresponding indice and "close"
+        column(s) representing the price as at the end of th
+        corresponding indice. If DataFrame covers multiple symbols then
+        columns should be indexed with a `pd.MultiIndex` with level 0 as
+        symbol.
+
+    window
+        Value to be passed to 'window` parameter of
+        `pd.DataFrame.rolling` to determine period over which
+        highs shoudl be evaluated, or None to evaluate all-time high.
+        Can be passed as:
+            `str` of a pandas frequency representing period over
+            which to evaluate highs, for example "365D" for '52wk'
+            highs.
+
+            `int` to define window as a fixed number of observations,
+            for example every 3 values.
+
+            `datetime.timedelta` to define window as a fixed period.
+
+            None to eveluate high as high since first observation
+            (all-time high).
+
+    include_current : bool
+        Determines if the evaluation of the high should include the
+        timestamp that represents the end of the period.
+        NB this options has no effect if evaluating high as all-time
+        high (i.e. if `window` is None), in which case high will
+        always be evaluated to include the current timestamp.
+    """
+    if window is None:
+        high = get_ath(data)
+        label = "ath"
+    else:
+        high = get_period_high(data, window, include_current)
+        label = f"{window}_high"
+
+    close = data[[c for c in data.columns if "close" in c]]
+    if isinstance(close.columns, pd.MultiIndex):
+        close.columns = close.columns.droplevel(1)
+    else:
+        assert len(high.columns) == 1
+        cols_index = pd.Index([label])
+        high.columns = cols_index
+        assert len(close.columns) == 1
+        close.columns = cols_index
+    return -100 * ((high - close) / high)

--- a/src/market_analy/standalone.py
+++ b/src/market_analy/standalone.py
@@ -1,0 +1,95 @@
+"""Standalone analysis functions."""
+
+import pandas as pd
+import valimp
+
+
+@valimp.parse
+def net_of(data: pd.DataFrame, rebase: bool = True) -> pd.DataFrame:
+    """Return OHLC data for one symbol net of changes of another.
+
+    For example, return OHLC data for an equity that discounts the effect
+    of the equity's wider market.
+
+    Parameters
+    ----------
+    data
+        `pd.DataFrame` with columns as `pd.MultiIndex` with:
+            level 0 representing two symbols. The return will reflect
+            the values of the first symbol net of those of the second
+            symbol.
+
+            level 1 as 'open', 'high', 'low', 'close' and, optionally,
+            'volume'.
+
+    rebase
+        True (default) to rebase net prices with first close value as
+        100.
+
+        False to not rebase net prices.
+
+    Examples
+    --------
+    >>> df = pd.DataFrame(
+    ...     {
+    ...         ("A", "open"): [18, 90, 50, 52, 78],
+    ...         ("A", "high"): [25, 120, 51, 52, 208],
+    ...         ("A", "low"): [15, 80, 49, 52, 52],
+    ...         ("A", "close"): [20, 100, 50, 52, 104],
+    ...         ("A", "volume"): [1, 2, 3, 4, 5],
+    ... # NB open, high, low and volume of 'other' have no effect
+    ...         ("B", "open"): [222, 333, 444, 555, 666],
+    ...         ("B", "high"): [444, 555, 666, 777, 888],
+    ...         ("B", "low"): [111, 222, 333, 444, 555],
+    ...         ("B", "close"): [10, 40, 30, 28.5, 57],
+    ...         ("B", "volume"): [1111, 2222, 3333, 4444, 5555],
+    ...     }
+    ... )
+    ... # 0, As A, no prior close
+    ... # 1, A rises 500%, B rises 400%, so net is 100% rise
+    ... # 2, A drops 50%, B drops 25%, so net is a 25% drop
+    ... # 3, A rises 4%, B falls 5%, so net is a 9% rise
+    ... # 4, A rises 100%, B rises 100%, so net is unchanged
+    >>> net_of(df, rebase=False).round(3)
+         open  high    low  close  volume
+    0  18.000  25.0  15.00   20.0       1
+    1  36.000  48.0  32.00   40.0       2
+    2  30.000  30.6  29.40   30.0       3
+    3  32.700  32.7  32.70   32.7       4
+    4  24.525  65.4  16.35   32.7       5
+    """
+    if not isinstance(data.columns, pd.MultiIndex):
+        raise ValueError("`data.columns` must be a `pd.MultiIndex`")
+    if len(data.columns.levels) != 2:
+        raise ValueError("`data.columns` must have two levels")
+    if len(data.columns.levels[0]) != 2:
+        raise ValueError("level 0 of `data.columns` must represent two symbols")
+
+    cols = [col for col in data.columns if col[1] == "close"]
+
+    chgs = []
+    for col in cols:
+        shifted = data[col].shift(1)
+        chgs.append((data[col] - shifted) / shifted)
+
+    # evaluate net percentage chg
+    chg_net = chgs[0] - chgs[1]
+
+    prev_close = 100 if rebase else data[cols[0]].iloc[0]
+    closes_ = [prev_close]
+    for chg in chg_net[1:]:
+        close = prev_close * (1 + chg)
+        closes_.append(close)
+        prev_close = close
+
+    closes = pd.Series(closes_, index=chg_net.index)
+    df = data[data.columns.levels[0][0]]
+    mapping = {
+        "close": closes,
+        "open": (df.open / df.close) * closes,
+        "high": (df.high / df.close) * closes,
+        "low": (df.low / df.close) * closes,
+        "volume": df.volume if "volume" in df.columns else None,
+    }
+
+    return pd.DataFrame({col: mapping[col] for col in df.columns})

--- a/src/market_analy/trends/charts.py
+++ b/src/market_analy/trends/charts.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 
 from ..cases import CaseSupportsChartAnaly
-from ..charts import TOOLTIP_STYLE, Groups, OHLCCaseBase, tooltip_html_style
+from ..charts import STYLE_TOOLTIP, Groups, OHLCCaseBase, tooltip_html_style
 from ..config import COL_ADV, COL_DEC
 from ..formatters import formatter_datetime, formatter_float, formatter_percent
 from ..utils import bq_utils as ubq
@@ -74,6 +74,7 @@ class TrendsChart(OHLCCaseBase):
         cases: MovementsSupportChartAnaly | None = None,
         handler_click_case: Callable | None = None,
         inc_conf_marks: bool = True,
+        data_y2: list[float | int] | None = None,
     ):
         if cases is None:
             raise ValueError("'cases' is a required argument.")
@@ -91,6 +92,7 @@ class TrendsChart(OHLCCaseBase):
             log_scale,
             display,
             handler_click_case,
+            data_y2,
         )
 
         self.cases: MovementsSupportChartAnaly
@@ -318,7 +320,7 @@ class TrendsChart(OHLCCaseBase):
             colors=[color_],
             line_style=line_style,
             tooltip=w.HTML(value=tooltip_str),
-            tooltip_style=TOOLTIP_STYLE,
+            tooltip_style=STYLE_TOOLTIP,
         )
         return line
 
@@ -367,7 +369,7 @@ class TrendsChart(OHLCCaseBase):
                 fill_colors=[color_area],
                 fill_opacities=[0.2],
                 tooltip=w.HTML(value=s),
-                tooltip_style=TOOLTIP_STYLE,
+                tooltip_style=STYLE_TOOLTIP,
             )
             self.add_marks([mark_chg], Groups.CASE, under=True)
 

--- a/src/market_analy/trends/guis.py
+++ b/src/market_analy/trends/guis.py
@@ -92,6 +92,7 @@ class TrendsGuiBase(GuiOHLCCaseBase):
     """
 
     _HAS_INTERVAL_SELECTOR = False
+    _HAS_DRAWDOWN = False
 
     def __init__(
         self,
@@ -107,7 +108,7 @@ class TrendsGuiBase(GuiOHLCCaseBase):
         chart_kwargs: dict | None = None,
         **kwargs,
     ):
-        data, _ = self._set_initial_data(analysis, interval, kwargs)
+        data, _, _ = self._set_initial_data(analysis, interval, kwargs)
         if isinstance(data.index, pd.IntervalIndex):
             data.index = data.index.left
             if data.index.tz is not None:
@@ -136,10 +137,6 @@ class TrendsGuiBase(GuiOHLCCaseBase):
     @property
     def _chart_title(self) -> str:
         return self._analysis.symbol + " Trend Analysis"
-
-    @property
-    def _include_drawdown(self) -> bool:
-        return False
 
     @property
     def _icon_row_top_handlers(self) -> list[Callable]:

--- a/src/market_analy/trends/guis.py
+++ b/src/market_analy/trends/guis.py
@@ -107,7 +107,7 @@ class TrendsGuiBase(GuiOHLCCaseBase):
         chart_kwargs: dict | None = None,
         **kwargs,
     ):
-        data = self._set_initial_prices(analysis, interval, kwargs).copy()
+        data, _ = self._set_initial_data(analysis, interval, kwargs)
         if isinstance(data.index, pd.IntervalIndex):
             data.index = data.index.left
             if data.index.tz is not None:
@@ -136,6 +136,10 @@ class TrendsGuiBase(GuiOHLCCaseBase):
     @property
     def _chart_title(self) -> str:
         return self._analysis.symbol + " Trend Analysis"
+
+    @property
+    def _include_drawdown(self) -> bool:
+        return False
 
     @property
     def _icon_row_top_handlers(self) -> list[Callable]:

--- a/src/market_analy/utils/bq_utils.py
+++ b/src/market_analy/utils/bq_utils.py
@@ -15,8 +15,10 @@ from traitlets import HasTraits, Any, dlink, link
 
 from market_analy.utils import UTC
 
-# possible keys for dictionary taken by +scales+ parameter of Axes class.
-ScaleKeys = Literal["x", "y", "color", "opacity", "size", "rotation", "skew"]
+# possible keys for dictionary taken by `scales` parameter of Axes class.
+# NB "y2" is not a key of the `scales` parameter but rather handled internally to
+# represent a secondary y axis
+ScaleKeys = Literal["x", "y", "y2", "color", "opacity", "size", "rotation", "skew"]
 
 # Colors for use on charts with dark backgrounds.
 COLORS_DARK_8 = [

--- a/src/market_analy/utils/ipywidgets_utils.py
+++ b/src/market_analy/utils/ipywidgets_utils.py
@@ -450,6 +450,9 @@ class DateRangeSlider(w.Box):
         else:
             if all(dti == dti.normalize()):
                 fmt = "%y/%m/%d"
+            elif dti[0] + pd.DateOffset(years=1) <= dti[-1]:
+                # errors triggered in slider if %y not present when range >= 1 year
+                fmt = "%y/%m/%d/%H:%M"
             elif dti[-1] - dti[0] > pd.Timedelta(days=28):
                 fmt = "%m/%d/%H:%M"
             else:

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1042,6 +1042,7 @@ class TestAnalysis:
         verify_chart_mark_y2_mult_windows(slice(2, -1))
 
         # verify effect of reset button
+        gui._drawdown_selector.value = False
         assert gui._icon_row_top.children[1].tooltip == "Reset"
         gui._icon_row_top.children[1].click()
         assert gui._interval_selector.value == mp.intervals.TDInterval.T5
@@ -1050,6 +1051,8 @@ class TestAnalysis:
         assert gui.chart.plotted_interval == expected_plottable
         assert gui.chart.plottable_interval == expected_plottable
         assert gui.date_slider.slider.value == expected_init
+        assert gui.chart.mark_y2.visible
+        assert gui.chart.axes[2].visible
 
         # verify raises dialog box when try to change interval to 1D for period < 1d
         prices_prev = gui.prices.copy()

--- a/tests/test_standalone.py
+++ b/tests/test_standalone.py
@@ -1,0 +1,85 @@
+"""Tests for the `market_analy.standalone` module."""
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from market_analy import standalone as m
+
+
+def test_net_of():
+    df = pd.DataFrame(
+        {
+            ("A", "open"): [18, 90, 50, 52, 78],
+            ("A", "high"): [25, 120, 51, 52, 208],
+            ("A", "low"): [15, 80, 49, 52, 52],
+            ("A", "close"): [20, 100, 50, 52, 104],
+            ("B", "open"): [222, 333, 444, 555, 666],
+            ("B", "high"): [444, 555, 666, 777, 888],
+            ("B", "low"): [111, 222, 333, 444, 555],
+            ("B", "close"): [10, 40, 30, 28.5, 57],
+        }
+    )
+
+    rtrn = m.net_of(df, rebase=False).round(3)
+
+    # 2nd day, A rises 500%, B rises 400%, so net is 100% rise (i.e. doubling)
+    # 3rd day, A drops 50%, B drops 25%, so net is a 25% drop
+    # 4rd day, A rises 4%, B falls 5%, so net is a 9% rise
+    # 5th day, A rises 100%, B rises 100%, so net is unchanged
+    expected_rtrn = pd.DataFrame(
+        {
+            "open": [18, 36, 30, 32.7, 24.525],
+            "high": [25, 48, 30.6, 32.7, 65.4],
+            "low": [15, 32, 29.4, 32.7, 16.35],
+            "close": [20, 40, 30, 32.7, 32.7],
+        }
+    )
+
+    assert_frame_equal(rtrn, expected_rtrn)
+
+    rtrn = m.net_of(df, rebase=True).round(3)
+
+    # test when rebased, as is by default
+
+    expected_rtrn = pd.DataFrame(
+        {
+            "open": [90, 180, 150, 163.5, 122.625],
+            "high": [125, 240, 153, 163.5, 327],
+            "low": [75, 160, 147, 163.5, 81.75],
+            "close": [100, 200, 150, 163.5, 163.5],
+        }
+    )
+
+    assert_frame_equal(rtrn, expected_rtrn)
+
+    # as first test although includes volume column which should
+    # be incuded in the result unchanged and wihtout influence from
+    # other volume
+    df = pd.DataFrame(
+        {
+            ("A", "open"): [18, 90, 50, 52, 78],
+            ("A", "high"): [25, 120, 51, 52, 208],
+            ("A", "low"): [15, 80, 49, 52, 52],
+            ("A", "close"): [20, 100, 50, 52, 104],
+            ("A", "volume"): [1, 2, 3, 4, 5],
+            ("B", "open"): [222, 333, 444, 555, 666],
+            ("B", "high"): [444, 555, 666, 777, 888],
+            ("B", "low"): [111, 222, 333, 444, 555],
+            ("B", "close"): [10, 40, 30, 28.5, 57],
+            ("B", "volume"): [1111, 2222, 3333, 4444, 5555],
+        }
+    )
+
+    rtrn = m.net_of(df, rebase=False).round(3)
+
+    expected_rtrn = pd.DataFrame(
+        {
+            "open": [18, 36, 30, 32.7, 24.525],
+            "high": [25, 48, 30.6, 32.7, 65.4],
+            "low": [15, 32, 29.4, 32.7, 16.35],
+            "close": [20, 40, 30, 32.7, 32.7],
+            "volume": [1, 2, 3, 4, 5],
+        }
+    )
+
+    assert_frame_equal(rtrn, expected_rtrn)


### PR DESCRIPTION
Adds option of including a drawdown plot to gui glasses. Implements for `GuiOHLC`, `GuiLine` and `GuiMultLine`.

Involved:
- adding 'get_high_*' functions to new `standalone.py` module.
- implementing option for chart classes (of `chart.py`) to have a secondary plot against a 'right' y-axis.
- implementing functionality to `guis.BasePrice` (to include adding drawdown period selection widget).

Also:
- fixes bug where gui dates slider would behave erratically for intraday data with range > 1 year.