### PR TITLE
Update dependencies

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -6,7 +6,7 @@
 #
 asttokens==3.0.0
     # via stack-data
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via yahooquery
 bqplot==0.12.44
     # via market_analy (pyproject.toml)
@@ -20,7 +20,7 @@ colorama==0.4.6
     #   tqdm
 comm==0.2.2
     # via ipywidgets
-contourpy==1.3.1
+contourpy==1.3.2
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
@@ -44,7 +44,7 @@ ipyvue==1.11.2
     # via ipyvuetify
 ipyvuetify==1.11.1
     # via market_analy (pyproject.toml)
-ipywidgets==8.1.5
+ipywidgets==8.1.6
     # via
     #   bqplot
     #   ipyvue
@@ -53,7 +53,7 @@ jedi==0.19.2
     # via ipython
 jinja2==3.1.6
     # via market_analy (pyproject.toml)
-jupyterlab-widgets==3.0.13
+jupyterlab-widgets==3.0.14
     # via ipywidgets
 kiwisolver==1.4.8
     # via matplotlib
@@ -69,7 +69,7 @@ matplotlib==3.10.1
     # via market_analy (pyproject.toml)
 matplotlib-inline==0.1.7
     # via ipython
-numpy==2.2.4
+numpy==2.2.5
     # via
     #   bqplot
     #   contourpy
@@ -78,7 +78,7 @@ numpy==2.2.4
     #   market_analy (pyproject.toml)
     #   matplotlib
     #   pandas
-packaging==24.2
+packaging==25.0
     # via matplotlib
 pandas==2.2.3
     # via
@@ -89,9 +89,9 @@ pandas==2.2.3
     #   yahooquery
 parso==0.8.4
     # via jedi
-pillow==11.1.0
+pillow==11.2.1
     # via matplotlib
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via ipython
 pure-eval==0.2.3
     # via stack-data
@@ -115,7 +115,7 @@ requests-futures==1.0.2
     # via yahooquery
 six==1.17.0
     # via python-dateutil
-soupsieve==2.6
+soupsieve==2.7
     # via beautifulsoup4
 stack-data==0.6.3
     # via ipython
@@ -134,7 +134,7 @@ traitlets==5.14.3
     #   traittypes
 traittypes==0.2.1
     # via bqplot
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   beautifulsoup4
     #   ipython
@@ -144,13 +144,13 @@ tzdata==2025.2
     #   market-prices
     #   market_analy (pyproject.toml)
     #   pandas
-urllib3==2.3.0
+urllib3==2.4.0
     # via requests
 valimp==0.3
     # via market-prices
 wcwidth==0.2.13
     # via prompt-toolkit
-widgetsnbextension==4.0.13
+widgetsnbextension==4.0.14
     # via ipywidgets
 yahooquery==2.3.7
     # via market-prices

--- a/etc/requirements_dependabot/requirements_tests.txt
+++ b/etc/requirements_dependabot/requirements_tests.txt
@@ -6,7 +6,7 @@
 #
 asttokens==3.0.0
     # via stack-data
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via yahooquery
 black==25.1.0
     # via market_analy (pyproject.toml)
@@ -26,7 +26,7 @@ colorama==0.4.6
     #   tqdm
 comm==0.2.2
     # via ipywidgets
-contourpy==1.3.1
+contourpy==1.3.2
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
@@ -60,7 +60,7 @@ ipyvue==1.11.2
     # via ipyvuetify
 ipyvuetify==1.11.1
     # via market_analy (pyproject.toml)
-ipywidgets==8.1.5
+ipywidgets==8.1.6
     # via
     #   bqplot
     #   ipyvue
@@ -69,7 +69,7 @@ jedi==0.19.2
     # via ipython
 jinja2==3.1.6
     # via market_analy (pyproject.toml)
-jupyterlab-widgets==3.0.13
+jupyterlab-widgets==3.0.14
     # via ipywidgets
 kiwisolver==1.4.8
     # via matplotlib
@@ -87,9 +87,9 @@ matplotlib-inline==0.1.7
     # via ipython
 mccabe==0.7.0
     # via flake8
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via black
-numpy==2.2.4
+numpy==2.2.5
     # via
     #   bqplot
     #   contourpy
@@ -98,7 +98,7 @@ numpy==2.2.4
     #   market_analy (pyproject.toml)
     #   matplotlib
     #   pandas
-packaging==24.2
+packaging==25.0
     # via
     #   black
     #   matplotlib
@@ -114,13 +114,13 @@ parso==0.8.4
     # via jedi
 pathspec==0.12.1
     # via black
-pillow==11.1.0
+pillow==11.2.1
     # via matplotlib
 platformdirs==4.3.7
     # via black
 pluggy==1.5.0
     # via pytest
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via ipython
 pure-eval==0.2.3
     # via stack-data
@@ -158,7 +158,7 @@ six==1.17.0
     # via python-dateutil
 snowballstemmer==2.2.0
     # via pydocstyle
-soupsieve==2.6
+soupsieve==2.7
     # via beautifulsoup4
 stack-data==0.6.3
     # via ipython
@@ -181,7 +181,7 @@ traitlets==5.14.3
     #   traittypes
 traittypes==0.2.1
     # via bqplot
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   beautifulsoup4
     #   black
@@ -192,13 +192,13 @@ tzdata==2025.2
     #   market-prices
     #   market_analy (pyproject.toml)
     #   pandas
-urllib3==2.3.0
+urllib3==2.4.0
     # via requests
 valimp==0.3
     # via market-prices
 wcwidth==0.2.13
     # via prompt-toolkit
-widgetsnbextension==4.0.13
+widgetsnbextension==4.0.14
     # via ipywidgets
 yahooquery==2.3.7
     # via market-prices

--- a/etc/requirements_dependabot/why_here.txt
+++ b/etc/requirements_dependabot/why_here.txt
@@ -1,8 +1,0 @@
-requirements_test.txt is in this dedicated directory simply so that
-dependabot can be configured to look only at these dependencies and ignore
-the additional requirements in requirements_dev.txt.
-
-Dependabot has to look at requirements_test.txt, as opposed to simply
-requirements.txt, in order that the tests triggered by the dependabot PR
-run in an environment that has installed the bumped versions of the
-dependencies.

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -26,7 +26,7 @@ attrs==25.3.0
     #   referencing
 babel==2.17.0
     # via jupyterlab-server
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   nbconvert
     #   yahooquery
@@ -65,17 +65,17 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.1
+contourpy==1.3.2
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-debugpy==1.8.13
+debugpy==1.8.14
     # via ipykernel
 decorator==5.2.1
     # via ipython
 defusedxml==0.7.1
     # via nbconvert
-dill==0.3.9
+dill==0.4.0
     # via pylint
 distlib==0.3.9
     # via virtualenv
@@ -106,11 +106,11 @@ fqdn==1.5.1
     # via jsonschema
 h11==0.14.0
     # via httpcore
-httpcore==1.0.7
+httpcore==1.0.8
     # via httpx
 httpx==0.28.1
     # via jupyterlab
-identify==2.6.9
+identify==2.6.10
     # via pre-commit
 idna==3.10
     # via
@@ -130,7 +130,7 @@ ipyvue==1.11.2
     # via ipyvuetify
 ipyvuetify==1.11.1
     # via market_analy (pyproject.toml)
-ipywidgets==8.1.5
+ipywidgets==8.1.6
     # via
     #   bqplot
     #   ipyvue
@@ -157,7 +157,7 @@ jsonschema[format-nongpl]==4.23.0
     #   jupyter-events
     #   jupyterlab-server
     #   nbformat
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
 jupyter-client==8.6.3
     # via
@@ -185,13 +185,13 @@ jupyter-server==2.15.0
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.4.0
+jupyterlab==4.4.1
     # via market_analy (pyproject.toml)
 jupyterlab-pygments==0.3.0
     # via nbconvert
 jupyterlab-server==2.27.3
     # via jupyterlab
-jupyterlab-widgets==3.0.13
+jupyterlab-widgets==3.0.14
     # via ipywidgets
 kiwisolver==1.4.8
     # via matplotlib
@@ -219,7 +219,7 @@ mistune==3.1.3
     # via nbconvert
 mypy==1.15.0
     # via market_analy (pyproject.toml)
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via
     #   black
     #   mypy
@@ -238,7 +238,7 @@ nodeenv==1.9.1
     # via pre-commit
 notebook-shim==0.2.4
     # via jupyterlab
-numpy==2.2.4
+numpy==2.2.5
     # via
     #   bqplot
     #   contourpy
@@ -250,7 +250,7 @@ numpy==2.2.4
     #   pandas-stubs
 overrides==7.7.0
     # via jupyter-server
-packaging==24.2
+packaging==25.0
     # via
     #   black
     #   build
@@ -277,7 +277,7 @@ parso==0.8.4
     # via jedi
 pathspec==0.12.1
     # via black
-pillow==11.1.0
+pillow==11.2.1
     # via matplotlib
 pip-tools==7.4.1
     # via market_analy (pyproject.toml)
@@ -293,7 +293,7 @@ pre-commit==4.2.0
     # via market_analy (pyproject.toml)
 prometheus-client==0.21.1
     # via jupyter-server
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via ipython
 psutil==7.0.0
     # via ipykernel
@@ -387,7 +387,7 @@ sniffio==1.3.1
     # via anyio
 snowballstemmer==2.2.0
     # via pydocstyle
-soupsieve==2.6
+soupsieve==2.7
     # via beautifulsoup4
 stack-data==0.6.3
     # via ipython
@@ -443,7 +443,7 @@ types-python-dateutil==2.9.0.20241206
     # via arrow
 types-pytz==2025.2.0.20250326
     # via pandas-stubs
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   anyio
     #   astroid
@@ -462,7 +462,7 @@ tzdata==2025.2
     #   pandas
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.3.0
+urllib3==2.4.0
     # via requests
 valimp==0.3
     # via market-prices
@@ -480,7 +480,7 @@ websocket-client==1.8.0
     # via jupyter-server
 wheel==0.45.1
     # via pip-tools
-widgetsnbextension==4.0.13
+widgetsnbextension==4.0.14
     # via ipywidgets
 yahooquery==2.3.7
     # via market-prices

--- a/etc/why_requirements_dependabot_dir.txt
+++ b/etc/why_requirements_dependabot_dir.txt
@@ -1,0 +1,9 @@
+requirements_test.txt is in the dedicated `requirements_dependabot`
+directory simply so that dependabot can be configured to look only at these
+dependencies and ignore the additional requirements in
+requirements_dev.txt.
+
+NB Dependabot has to look at requirements_tests.txt, as opposed to simply
+requirements.txt, in order that the tests triggered by the dependabot PR
+run in an environment that has installed the bumped versions of the
+dependencies.


### PR DESCRIPTION
Updates dependencies.

Also moves (and renames) the `why_here.txt` info file out of the `requirements_dependabot` directory as it seems this arrangement is no longer compatible with dependabot's search for requirement files - appears dependabot now looks at all files in the directory regardless of file name and contents.