### PR TITLE
Add base classes for position analysis

### DIFF
--- a/src/market_analy/positions/__init__.py
+++ b/src/market_analy/positions/__init__.py
@@ -1,0 +1,12 @@
+"""Base classes for position analysis.
+
+Provides base classes for representing positions, charting
+positions, and creating interactive position GUIs.
+"""
+
+from .charts import ChartPositionsBase as ChartPositionsBase
+from .charts import distributed_rtrns as distributed_rtrns
+from .guis import PositionsGuiBase as PositionsGuiBase
+from .positions import ConsolidatedBase as ConsolidatedBase
+from .positions import PositionBase as PositionBase
+from .positions import PositionsBase as PositionsBase

--- a/src/market_analy/positions/charts.py
+++ b/src/market_analy/positions/charts.py
@@ -1,0 +1,254 @@
+"""Base charts for analysis of positions."""
+
+from __future__ import annotations
+
+import typing
+from typing import TYPE_CHECKING
+
+import bqplot as bq
+import numpy as np
+from bqplot import Lines
+
+import market_analy.utils.bq_utils as ubq
+from market_analy.cases import ChartSupportsCasesGui
+from market_analy.charts import Groups, OHLCCaseBase, tooltip_html_style
+from market_analy.formatters import formatter_datetime, formatter_float
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import pandas as pd
+
+    from .positions import PositionBase, PositionsBase
+
+
+class ChartPositionsBase(OHLCCaseBase, ChartSupportsCasesGui):
+    """Chart positions taken in a single instrument.
+
+    OHLC chart with positions overlay. Each position represented
+    by:
+        Single line tracking price (as `PositionBase.line`).
+        Line is green for profitable positions, red for
+        positions that are not profitable.
+
+        Scatter mark point representing position open (circle).
+        This point also represents the position more generally.
+
+        Scatter mark point representing position close (cross).
+
+    Parameters
+    ----------
+    As for OHLCCaseBase except:
+
+    cases
+        Positions over period to be charted.
+    """
+
+    def __init__(
+        self,
+        prices: pd.DataFrame,
+        cases: PositionsBase,
+        title: str,
+        visible_x_ticks: pd.Interval | None = None,
+        max_ticks: int | None = None,
+        *,
+        log_scale: bool = True,
+        display: bool = False,
+        handler_click_case: Callable | None = None,
+        data_y2: None = None,
+    ):
+        super().__init__(
+            prices,
+            cases,
+            title,
+            visible_x_ticks,
+            max_ticks,
+            log_scale,
+            display,
+            handler_click_case,
+            data_y2,
+        )
+
+        self.cases: PositionsBase
+
+    @property
+    def current_case(self) -> PositionBase | None:
+        """Currently selected position."""
+        case = super().current_case
+        if typing.TYPE_CHECKING:
+            assert isinstance(case, PositionBase)
+        return case
+
+    def _add_marks(self, **_) -> None:
+        """Add marks.
+
+        Represents each position with:
+            Line tracking position.
+            Point on a Scatter ('circle') indicating open.
+            Point on a Scatter ('cross') indicating close.
+        """
+        colors = [
+            "lime" if profitable else "crimson" for profitable in self.cases.profitables
+        ]
+        lines = []
+        for line, color in zip(self.cases.lines, colors, strict=True):
+            lines.append(
+                Lines(
+                    scales=self.scales,
+                    colors=[color],
+                    x=line.index,
+                    y=line.values,
+                    stroke_width=5,
+                    line_style="solid",
+                    interpolation="linear",
+                )
+            )
+        self.add_marks(lines, Groups.CASES_OTHER_0)
+
+        # scatter for position opens
+        self._add_scatter(
+            self.cases.open_dates,
+            self.cases.open_pxs,
+            colors,
+            "circle",
+            self.handler_hover_open,
+            self._handler_click_case,
+        )
+
+        # scatters for closes
+        self._add_scatter(
+            self.cases.close_dates,
+            self.cases.close_pxs,
+            colors,
+            "cross",
+            self.handler_hover_close,
+        )
+
+    def handler_hover_open(self, mark: bq.marks.Scatter, event: dict) -> None:
+        """Handler for hovering on position open mark.
+
+        Displays tooltip describing scatter point.
+        """
+        pos = self.cases.event_to_case(mark, event)
+        mark.tooltip.value = self.cases.get_case_html(pos)
+
+    def handler_hover_close(self, mark: bq.Scatter, event: dict) -> None:
+        """Handler for hovering on position close mark.
+
+        Displays tooltip describing scatter point.
+        """
+        pos = self.cases.event_to_case(mark, event)
+        i = self.cases.get_index(pos)
+        color = mark.colors[i]
+        style = tooltip_html_style(color=color, line_height=1.3)
+        date = ubq.discontinuous_date_to_timestamp(event["data"]["x"])
+        s = f"<p {style}>Close: {formatter_datetime(date)}"
+        s += f"<br>Close px: {formatter_float(event['data']['y'])}</p"
+        mark.tooltip.value = s
+
+
+def distributed_rtrns(
+    rtrns: pd.Series,
+) -> bq.Figure:  # type: ignore[return-value]
+    """Return chart describing distribution of returns.
+
+    Parameters
+    ----------
+    rtrns
+        Series describing return of each scenario.
+
+    Notes
+    -----
+    Very rough. Develop / Refactor as required.
+    """
+    if not rtrns.is_monotonic_decreasing:
+        rtrns = rtrns.sort_values(ascending=False)
+
+    srs = rtrns.reset_index(drop=True)
+
+    scale_x = bq.LinearScale()  # type: ignore[attr-defined]
+    scale_y = bq.LinearScale()  # type: ignore[attr-defined]
+    kwargs = {
+        "scales": {"x": scale_x, "y": scale_y},
+        "stroke_width": 3,
+        "fill_opacities": [0.7],
+        "fill": "between",
+        "display_legend": True,
+    }
+    axis_x = bq.Axis(
+        orientation="horizontal",
+        side="bottom",
+        scale=scale_x,
+        offset={"scale": scale_y, "value": 0},
+    )
+
+    axis_y = bq.Axis(
+        orientation="vertical",
+        side="left",
+        scale=scale_y,
+    )
+
+    marks = []
+    bv = srs > 0
+    if bv.any():
+        label1 = str(round(srs[bv].sum(), 2))
+        if str(rtrns.index.dtype) == "object":
+            label1 += " " + ", ".join(rtrns.index[bv][:5].tolist())
+        marks.append(
+            bq.Lines(  # type: ignore[attr-defined]
+                y=[
+                    srs[bv].to_numpy(),
+                    np.array([0] * len(srs[bv])),
+                ],
+                x=srs[bv].index,
+                colors=["Lime", "Gray"],
+                fill_colors=["Green"],
+                labels=[label1, str(len(srs[bv]))],
+                **kwargs,
+            )
+        )
+    bv = srs < 0
+    if bv.any():
+        label1 = str(round(srs[bv].sum(), 2))
+        if str(rtrns.index.dtype) == "object":
+            label1 += " " + ", ".join(rtrns.index[bv][-5:].tolist()[::-1])
+        marks.append(
+            bq.Lines(  # type: ignore[attr-defined]
+                y=[
+                    srs[bv].to_numpy(),
+                    np.array([0] * len(srs[bv])),
+                ],
+                x=srs[bv].index,
+                colors=["Red", "Gray"],
+                fill_colors=["Firebrick"],
+                labels=[label1, str(len(srs[bv]))],
+                **kwargs,
+            )
+        )
+    bv = srs == 0
+    if bv.any():
+        marks.append(
+            bq.Lines(  # type: ignore[attr-defined]
+                y=srs[bv],
+                x=srs[bv].index,
+                colors=["SkyBlue"],
+                labels=[str(len(srs[bv]))],
+                **kwargs,
+            )
+        )
+
+    return bq.Figure(  # type: ignore[attr-defined]
+        title="Distributed Returns",
+        title_style={"fill": "white"},
+        axes=[axis_x, axis_y],
+        marks=marks,
+        scale_x=scale_x,
+        scale_y=scale_y,
+        fig_margin={
+            "left": 100,
+            "right": 180,
+            "top": 30,
+            "bottom": 30,
+        },
+        legend_location="bottom-left",
+    )

--- a/src/market_analy/positions/charts.py
+++ b/src/market_analy/positions/charts.py
@@ -107,7 +107,7 @@ class ChartPositionsBase(OHLCCaseBase, ChartSupportsCasesGui):
 
         # scatter for position opens
         self._add_scatter(
-            self.cases.open_dates,
+            self.cases.open_bars,
             self.cases.open_pxs,
             colors,
             "circle",
@@ -117,7 +117,7 @@ class ChartPositionsBase(OHLCCaseBase, ChartSupportsCasesGui):
 
         # scatters for closes
         self._add_scatter(
-            self.cases.close_dates,
+            self.cases.close_bars,
             self.cases.close_pxs,
             colors,
             "cross",

--- a/src/market_analy/positions/guis.py
+++ b/src/market_analy/positions/guis.py
@@ -1,0 +1,135 @@
+"""Base GUIs to visualise and analyse position data."""
+
+from __future__ import annotations
+
+import typing
+
+from market_analy.guis import GuiOHLCCaseBase
+
+from . import charts
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import market_prices as mp
+
+    from market_analy import analysis as ma_analysis
+
+    from .positions import PositionBase, PositionsBase
+
+
+class PositionsGuiBase(GuiOHLCCaseBase):
+    """Base GUI to display and interact with positions.
+
+    See `GuiOHLCCaseBase` for documentation of parameters
+    and methods defined on the base class.
+
+    Parameters
+    ----------
+    analysis
+        Analysis instance representing instrument to be
+        plotted.
+
+    interval
+        Interval covered by one bar.
+
+    cases
+        Positions to display.
+
+    max_ticks
+        Maximum number of bars (x-axis ticks) that will shown
+        by default. None for no limit.
+
+    log_scale
+        True to plot prices against a log scale. False to plot
+        prices against a linear scale.
+
+    display
+        True to display created GUI.
+
+    narrow_view
+        Number of bars shown before/after a position in
+        'narrow' view.
+
+    wide_view
+        Number of bars shown before/after a position in
+        'wide' view.
+
+    chart_kwargs
+        Any kwargs to pass on to the chart class.
+
+    **kwargs
+        Period parameters as described by market-prices
+        documentation.
+
+    Notes
+    -----
+    -- Subclass Implementation --
+
+    Subclasses should prepare data and cases (positions) in
+    their own ``__init__`` and pass them to this base class.
+    Subclasses can also:
+
+        Override `ChartCls` to return a specific chart class.
+
+        Override `_chart_title` to provide a specific title.
+
+        Concrete constructor arguments such as `narrow_view`,
+        `wide_view` etc.
+    """
+
+    _HAS_INTERVAL_SELECTOR = False
+
+    def __init__(
+        self,
+        analysis: ma_analysis.Analysis,
+        interval: mp.intervals.RowInterval,
+        cases: PositionsBase,
+        max_ticks: int | None = None,
+        *,
+        log_scale: bool = True,
+        display: bool = True,
+        narrow_view: int = 15,
+        wide_view: int = 50,
+        chart_kwargs: dict | None = None,
+        **kwargs,
+    ):
+        super().__init__(
+            analysis,
+            interval,
+            cases,
+            max_ticks,
+            log_scale,
+            display,
+            narrow_view,
+            wide_view,
+            chart_kwargs,
+            **kwargs,
+        )
+
+        self.cases: PositionsBase
+
+    @property
+    def ChartCls(self) -> type[charts.ChartPositionsBase]:  # noqa: N802
+        """Chart class."""
+        return charts.ChartPositionsBase
+
+    @property
+    def _chart_title(self) -> str:
+        return self._analysis.symbol + " Positions Analysis"
+
+    @property
+    def _icon_row_top_handlers(self) -> list[Callable]:
+        return [
+            self._max_x_ticks,
+            self._resize_chart,
+            self.close,
+        ]
+
+    @property
+    def current_case(self) -> PositionBase | None:
+        """Current selected case."""
+        case = super().current_case
+        if case is None:
+            return None
+        return typing.cast("PositionBase", case)

--- a/src/market_analy/positions/positions.py
+++ b/src/market_analy/positions/positions.py
@@ -38,44 +38,42 @@ class PositionBase(CaseBase, CaseSupportsChartAnaly):
     Attributes
     ----------
     data
-        OHLC daily prices.
+        OHLC prices.
 
-        Index should represent all sessions over which the
-        position was open, inclusive of both the session during
-        which it was opened and the session during which it was
-        closed.
+        Index should represent all bars over which the position
+        was open, inclusive of both the bar during which it was
+        opened and the bar during which it was closed.
 
         The OHLC columns should represent:
 
-            'open' - price as at session open, except for session
-            during which position opened, for which should be
-            price at which position was opened.
+            'open' - price as at bar open, except for bar during
+            which position opened, for which should be price at
+            which position was opened.
 
-            'high'/'low' - price as at session high/low except on
-            sessions when position opened or closed, in which
-            case should not include any information outside of
-            the period during which the position was held. For
-            session when position was opened the 'high'/'low'
-            should be session high/low following the position's
-            open. For session when position was closed the
-            'high'/'low' should be session high/low as at the
-            time the position was closed. If it is not possible
-            to evaluate either value then the value should be
-            defined as 'np.NaN'.
-            NOTE: 'high' for session when position is closed is
-            ASSUMED as that sessions' high. Without this
-            assumption the `max_date` and `max_px` properties
-            would be otherwise inaccurate whenever the maximum
-            price was registered prior to a reversal on the
-            session the position was closed. With this assumption
-            the `max_date` and `max_px` properties will be
-            inaccurate whenever following a position being closed
-            the price moves back to and extends the high before
-            the end of the session.
+            'high'/'low' - price as at bar high/low except on
+            bars when position opened or closed, in which case
+            should not include any information outside of the
+            period during which the position was held. For the
+            bar when position was opened the 'high'/'low' should
+            be bar high/low following the position's open. For
+            the bar when position was closed the 'high'/'low'
+            should be bar high/low as at the time the position
+            was closed. If it is not possible to evaluate either
+            value then the value should be defined as 'np.NaN'.
+            NOTE: 'high' for the bar when position is closed is
+            ASSUMED as that bar's high. Without this assumption
+            the `max_bar` and `max_px` properties would be
+            otherwise inaccurate whenever the maximum price was
+            registered prior to a reversal on the bar the
+            position was closed. With this assumption the
+            `max_bar` and `max_px` properties will be inaccurate
+            whenever following a position being closed the price
+            moves back to and extends the high before the end of
+            the bar.
 
-            'close' - price as at session close, except of
-            session during which position closed, in which should
-            should be price at which position was closed.
+            'close' - price as at bar close, except of bar
+            during which position closed, in which should should
+            be price at which position was closed.
 
     closed
         True - position closed as at end of available data.
@@ -92,29 +90,29 @@ class PositionBase(CaseBase, CaseSupportsChartAnaly):
     spread: float
 
     @property
-    def sessions(self) -> pd.DatetimeIndex:
-        """Sessions over which position was held.
+    def bars(self) -> pd.DatetimeIndex:
+        """Bars over which position was held.
 
-        Inclusive of session during which position opened and
-        session during which position closed.
+        Inclusive of bar during which position opened and bar
+        during which position closed.
         """
         index = self.data.index
         index = typing.cast("pd.DatetimeIndex", index)
         return index  # noqa: RET504
 
     @property
-    def open_date(self) -> pd.Timestamp:
-        """Session when position opened."""
-        return self.sessions[0]
+    def open_bar(self) -> pd.Timestamp:
+        """Bar when position opened."""
+        return self.bars[0]
 
     @property
-    def close_date(self) -> pd.Timestamp:
-        """Session when position closed.
+    def close_bar(self) -> pd.Timestamp:
+        """Bar when position closed.
 
-        If position not closed then most recent session of
-        analysis period.
+        If position not closed then most recent bar of analysis
+        period.
         """
-        return self.sessions[-1]
+        return self.bars[-1]
 
     @property
     def open_px(self) -> float:
@@ -167,9 +165,9 @@ class PositionBase(CaseBase, CaseSupportsChartAnaly):
         return self.rtrn_net > 0
 
     @property
-    def max_date(self) -> pd.Timestamp:
-        """Session when position reached highest registered price."""
-        return self.sessions[self.data.high == self.max_px][0]
+    def max_bar(self) -> pd.Timestamp:
+        """Bar when position reached highest registered price."""
+        return self.bars[self.data.high == self.max_px][0]
 
     @property
     def max_px(self) -> float:
@@ -196,7 +194,7 @@ class PositionBase(CaseBase, CaseSupportsChartAnaly):
 
     @property
     def duration(self) -> int:
-        """Position duration, in sessions, part or full."""
+        """Position duration, in bars, part or full."""
         return len(self.data)
 
     @property
@@ -206,16 +204,15 @@ class PositionBase(CaseBase, CaseSupportsChartAnaly):
         Returns
         -------
         pd.Series
-            DatetimeIndex represents sessions. Value (dtype
-            float) represents: For session during which position
-            was opened, the price the position was opened at and
-            the price as at the end of the session. The two
-            prices are provided by way of consecutive rows with
-            the same index value, with the first representing the
-            price at which the position was opened. For session
-            during which position was closed, the price the
-            position was closed at. For all other sessions, the
-            price as at the end of that session.
+            Index represents bars. Value (dtype float)
+            represents: For bar during which position was opened,
+            the price the position was opened at and the price as
+            at the end of the bar. The two prices are provided by
+            way of consecutive rows with the same index value,
+            with the first representing the price at which the
+            position was opened. For bar during which position
+            was closed, the price the position was closed at. For
+            all other bars, the price as at the end of that bar.
         """
         srs = self.data["close"].copy()
         srs.name = "price"
@@ -225,7 +222,7 @@ class PositionBase(CaseBase, CaseSupportsChartAnaly):
     @property
     def _start(self) -> pd.Timestamp:
         """Bar when case considered to start."""
-        return self.open_date
+        return self.open_bar
 
     @property
     def _end(self) -> pd.Timestamp | None:
@@ -234,7 +231,7 @@ class PositionBase(CaseBase, CaseSupportsChartAnaly):
         None if case had not concluded as at end of available
         data.
         """
-        return self.close_date
+        return self.close_bar
 
 
 @dataclass(frozen=True)
@@ -265,9 +262,9 @@ class PositionsBase(CasesBase, CasesSupportsChartAnaly):
         return [pos.line for pos in self.cases]
 
     @property
-    def open_dates(self) -> list[pd.Timestamp]:
-        """Open dates of all positions."""
-        return [pos.open_date for pos in self.cases]
+    def open_bars(self) -> list[pd.Timestamp]:
+        """Open bars of all positions."""
+        return [pos.open_bar for pos in self.cases]
 
     @property
     def open_pxs(self) -> list[float]:
@@ -275,9 +272,9 @@ class PositionsBase(CasesBase, CasesSupportsChartAnaly):
         return [pos.open_px for pos in self.cases]
 
     @property
-    def close_dates(self) -> list[pd.Timestamp]:
-        """Close dates of all positions."""
-        return [pos.close_date for pos in self.cases]
+    def close_bars(self) -> list[pd.Timestamp]:
+        """Close bars of all positions."""
+        return [pos.close_bar for pos in self.cases]
 
     @property
     def close_pxs(self) -> list[float]:
@@ -285,9 +282,9 @@ class PositionsBase(CasesBase, CasesSupportsChartAnaly):
         return [pos.close_px for pos in self.cases]
 
     @property
-    def max_dates(self) -> list[pd.Timestamp]:
-        """Sessions when positions registered highest prices."""
-        return [pos.max_date for pos in self.cases]
+    def max_bars(self) -> list[pd.Timestamp]:
+        """Bars when positions registered highest prices."""
+        return [pos.max_bar for pos in self.cases]
 
     @property
     def max_pxs(self) -> list[float]:
@@ -339,16 +336,16 @@ class PositionsBase(CasesBase, CasesSupportsChartAnaly):
         case = typing.cast("PositionBase", case)
         color = "limegreen" if case.profitable else "crimson"
         style = tooltip_html_style(color=color, line_height=1.3)
-        s = f"<p {style}>Open: " + formatter_datetime(case.open_date)
+        s = f"<p {style}>Open: " + formatter_datetime(case.open_bar)
         s += f"<br>Open px: {formatter_float(case.open_px)}"
-        close = "None" if not case.closed else formatter_datetime(case.close_date)
+        close = "None" if not case.closed else formatter_datetime(case.close_bar)
         s += f"<br>Close: {close}"
         close_px = "None" if not case.closed else formatter_float(case.close_px)
         s += f"<br>Close px: {close_px}"
         s += f"<br>Chg: {formatter_float(case.chg_abs)}"
         s += f"<br>Rtrn (net): {formatter_percent(case.rtrn_net)}"
         s += f"<br>Duration: {case.duration}"
-        s += f"<br>Max date: {formatter_datetime(case.max_date)}"
+        s += f"<br>Max bar: {formatter_datetime(case.max_bar)}"
         s += f"<br>Max px: {formatter_float(case.max_px)}"
         s += f"<br>Max Rtrn (net): {formatter_percent(case.rtrn_net_max)}"
         return s

--- a/src/market_analy/positions/positions.py
+++ b/src/market_analy/positions/positions.py
@@ -1,0 +1,456 @@
+"""Base classes to represent positions.
+
+`PositionBase` offers a base class to represent a single position
+taken in a financial instrument.
+
+`PositionsBase` offers a base class to represent all positions
+taken in a single financial instrument over an analysis period.
+
+`ConsolidatedBase` provides a base class to consolidate the
+results of positions taken across multiple instruments.
+"""
+
+import typing
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import bqplot as bq
+import pandas as pd
+
+from market_analy.cases import (
+    CaseBase,
+    CasesBase,
+    CasesSupportsChartAnaly,
+    CaseSupportsChartAnaly,
+)
+from market_analy.charts import tooltip_html_style
+from market_analy.formatters import (
+    formatter_datetime,
+    formatter_float,
+    formatter_percent,
+)
+
+
+@dataclass(frozen=True, eq=False)
+class PositionBase(CaseBase, CaseSupportsChartAnaly):
+    """Base for classes defining a position.
+
+    Attributes
+    ----------
+    data
+        OHLC daily prices.
+
+        Index should represent all sessions over which the
+        position was open, inclusive of both the session during
+        which it was opened and the session during which it was
+        closed.
+
+        The OHLC columns should represent:
+
+            'open' - price as at session open, except for session
+            during which position opened, for which should be
+            price at which position was opened.
+
+            'high'/'low' - price as at session high/low except on
+            sessions when position opened or closed, in which
+            case should not include any information outside of
+            the period during which the position was held. For
+            session when position was opened the 'high'/'low'
+            should be session high/low following the position's
+            open. For session when position was closed the
+            'high'/'low' should be session high/low as at the
+            time the position was closed. If it is not possible
+            to evaluate either value then the value should be
+            defined as 'np.NaN'.
+            NOTE: 'high' for session when position is closed is
+            ASSUMED as that sessions' high. Without this
+            assumption the `max_date` and `max_px` properties
+            would be otherwise inaccurate whenever the maximum
+            price was registered prior to a reversal on the
+            session the position was closed. With this assumption
+            the `max_date` and `max_px` properties will be
+            inaccurate whenever following a position being closed
+            the price moves back to and extends the high before
+            the end of the session.
+
+            'close' - price as at session close, except of
+            session during which position closed, in which should
+            should be price at which position was closed.
+
+    closed
+        True - position closed as at end of available data.
+        False - position remained open as at end of available
+        data.
+
+    spread
+        Difference between mid and bid or offer. As float
+        representing percentage, for example 0.002 for 0.2%.
+    """
+
+    data: pd.DataFrame
+    closed: bool
+    spread: float
+
+    @property
+    def sessions(self) -> pd.DatetimeIndex:
+        """Sessions over which position was held.
+
+        Inclusive of session during which position opened and
+        session during which position closed.
+        """
+        index = self.data.index
+        index = typing.cast("pd.DatetimeIndex", index)
+        return index  # noqa: RET504
+
+    @property
+    def open_date(self) -> pd.Timestamp:
+        """Session when position opened."""
+        return self.sessions[0]
+
+    @property
+    def close_date(self) -> pd.Timestamp:
+        """Session when position closed.
+
+        If position not closed then most recent session of
+        analysis period.
+        """
+        return self.sessions[-1]
+
+    @property
+    def open_px(self) -> float:
+        """Mid-price when position opened."""
+        return self.data.iloc[0].open
+
+    @property
+    def close_px(self) -> float:
+        """Mid-price when position closed.
+
+        If position not closed then most recent price of
+        analysis period.
+        """
+        return self.data.iloc[-1].close
+
+    @property
+    def chg_abs(self) -> float:
+        """Absolute difference between open and close price.
+
+        If position not closed then absolute difference between
+        open price and most recent close price from available
+        data.
+
+        NOTE Does NOT account for spread.
+        """
+        return self.close_px - self.open_px
+
+    @property
+    def rtrn_gross(self) -> float:
+        """Return gross of any costs.
+
+        Does not account for spread.
+        """
+        return self.chg_abs / self.open_px
+
+    @property
+    def rtrn_net(self) -> float:
+        """Return net of spread.
+
+        Does not account for any costs other than spread.
+        """
+        return self.rtrn_gross - (2 * self.spread)
+
+    @property
+    def profitable(self) -> bool:
+        """Query if profitable on a net basis.
+
+        NOTE: Only spread is considered within costs.
+        """
+        return self.rtrn_net > 0
+
+    @property
+    def max_date(self) -> pd.Timestamp:
+        """Session when position reached highest registered price."""
+        return self.sessions[self.data.high == self.max_px][0]
+
+    @property
+    def max_px(self) -> float:
+        """Highest mid-price registered whilst position held."""
+        return self.data.high.max()
+
+    @property
+    def chg_abs_max(self) -> float:
+        """Absolute difference between open and maximum price.
+
+        NOTE Does NOT account for spread.
+        """
+        return self.max_px - self.open_px
+
+    @property
+    def rtrn_gross_max(self) -> float:
+        """Maximum gross return registered during position."""
+        return self.chg_abs_max / self.open_px
+
+    @property
+    def rtrn_net_max(self) -> float:
+        """Maximum return registered, net of spread."""
+        return self.rtrn_gross_max - (2 * self.spread)
+
+    @property
+    def duration(self) -> int:
+        """Position duration, in sessions, part or full."""
+        return len(self.data)
+
+    @property
+    def line(self) -> pd.Series:
+        """Line representing position over time.
+
+        Returns
+        -------
+        pd.Series
+            DatetimeIndex represents sessions. Value (dtype
+            float) represents: For session during which position
+            was opened, the price the position was opened at and
+            the price as at the end of the session. The two
+            prices are provided by way of consecutive rows with
+            the same index value, with the first representing the
+            price at which the position was opened. For session
+            during which position was closed, the price the
+            position was closed at. For all other sessions, the
+            price as at the end of that session.
+        """
+        srs = self.data["close"].copy()
+        srs.name = "price"
+        first_row = pd.Series([self.open_px], index=srs.index[:1], name="price")
+        return pd.concat((first_row, srs))
+
+    @property
+    def _start(self) -> pd.Timestamp:
+        """Bar when case considered to start."""
+        return self.open_date
+
+    @property
+    def _end(self) -> pd.Timestamp | None:
+        """Bar when case considered to have concluded.
+
+        None if case had not concluded as at end of available
+        data.
+        """
+        return self.close_date
+
+
+@dataclass(frozen=True)
+class PositionsBase(CasesBase, CasesSupportsChartAnaly):
+    """All positions over an analysis period.
+
+    Attributes
+    ----------
+    cases
+        Ordered sequence of all positions that would have been
+        taken during analysis period defined by `data`.
+
+    data
+        OHLC data in which `cases` identified.
+
+    ticker
+        Ticker with which the analysis corresponds, for example
+        "MSFT".
+    """
+
+    cases: Sequence[PositionBase]
+    data: pd.DataFrame
+    ticker: str
+
+    @property
+    def lines(self) -> list[pd.Series]:
+        """Lines representing positions over time."""
+        return [pos.line for pos in self.cases]
+
+    @property
+    def open_dates(self) -> list[pd.Timestamp]:
+        """Open dates of all positions."""
+        return [pos.open_date for pos in self.cases]
+
+    @property
+    def open_pxs(self) -> list[float]:
+        """Open prices for all positions."""
+        return [pos.open_px for pos in self.cases]
+
+    @property
+    def close_dates(self) -> list[pd.Timestamp]:
+        """Close dates of all positions."""
+        return [pos.close_date for pos in self.cases]
+
+    @property
+    def close_pxs(self) -> list[float]:
+        """Close prices for all positions."""
+        return [pos.close_px for pos in self.cases]
+
+    @property
+    def max_dates(self) -> list[pd.Timestamp]:
+        """Sessions when positions registered highest prices."""
+        return [pos.max_date for pos in self.cases]
+
+    @property
+    def max_pxs(self) -> list[float]:
+        """Highest prices registered by positions."""
+        return [pos.max_px for pos in self.cases]
+
+    @property
+    def rtrns_gross(self) -> list[float]:
+        """Positions gross returns."""
+        return [pos.rtrn_gross for pos in self.cases]
+
+    @property
+    def rtrns_net(self) -> list[float]:
+        """Positions net returns."""
+        return [pos.rtrn_net for pos in self.cases]
+
+    @property
+    def profitables(self) -> list[bool]:
+        """Query if positions were profitable."""
+        return [pos.profitable for pos in self.cases]
+
+    @property
+    def rtrn_gross(self) -> float:
+        """Aggregated gross return across all positions."""
+        return sum(self.rtrns_gross)
+
+    @property
+    def rtrn_net(self) -> float:
+        """Aggregated net return across all positions."""
+        return sum(self.rtrns_net)
+
+    @property
+    def profitable(self) -> bool:
+        """Query if positions profitable in aggregate (net).
+
+        NOTE: Only spread is considered within costs.
+        """
+        return self.rtrn_net > 0
+
+    @staticmethod
+    def get_case_html(case: CaseSupportsChartAnaly) -> str:
+        """Return html to describe a position.
+
+        Parameters
+        ----------
+        case
+            Case for which to get html.
+        """
+        case = typing.cast("PositionBase", case)
+        color = "limegreen" if case.profitable else "crimson"
+        style = tooltip_html_style(color=color, line_height=1.3)
+        s = f"<p {style}>Open: " + formatter_datetime(case.open_date)
+        s += f"<br>Open px: {formatter_float(case.open_px)}"
+        close = "None" if not case.closed else formatter_datetime(case.close_date)
+        s += f"<br>Close: {close}"
+        close_px = "None" if not case.closed else formatter_float(case.close_px)
+        s += f"<br>Close px: {close_px}"
+        s += f"<br>Chg: {formatter_float(case.chg_abs)}"
+        s += f"<br>Rtrn (net): {formatter_percent(case.rtrn_net)}"
+        s += f"<br>Duration: {case.duration}"
+        s += f"<br>Max date: {formatter_datetime(case.max_date)}"
+        s += f"<br>Max px: {formatter_float(case.max_px)}"
+        s += f"<br>Max Rtrn (net): {formatter_percent(case.rtrn_net_max)}"
+        return s
+
+    def __repr__(self) -> str:
+        return (
+            f"<{self.__class__} {self.ticker}"
+            f" {round(self.rtrn_net * 100, 1)}"
+            f" {round(self.rtrn_gross * 100, 1)}"
+        )
+
+
+class ConsolidatedBase:
+    """Summary of positions across instruments over an analysis period.
+
+    Attributes
+    ----------
+    results
+        `PositionsBase` for each instrument over the analysis
+        period.
+    """
+
+    def __init__(self, results: Sequence[PositionsBase]):
+        self.results = {res.ticker: res for res in results}
+
+        tickers = [res.ticker for res in results]
+        net = [res.rtrn_net for res in results]
+        gross = [res.rtrn_gross for res in results]
+
+        df = pd.DataFrame({"net": net, "gross": gross}, index=tickers)
+        df = df.sort_values(by="net", ascending=False)
+
+        df["net_pct"] = (df["net"] * 100).round(1)
+        df["gross_pct"] = (df["gross"] * 100).round(1)
+
+        self._rtrns = df
+
+    @property
+    def num_symbols(self) -> int:
+        """Number of instruments in consolidated analysis."""
+        return len(self.results)
+
+    @property
+    def rtrns(self) -> pd.DataFrame:
+        """Returns."""
+        return self._rtrns[["net", "gross"]]
+
+    @property
+    def rtrns_pct(self) -> pd.DataFrame:
+        """Returns as percent change."""
+        df = self._rtrns[["net_pct", "gross_pct"]]
+        df.columns = pd.Index(["net", "gross"])
+        return df
+
+    @property
+    def profitables_pct(self) -> float:
+        """Percentage of instruments that were net profitable."""
+        return round(
+            100 * (self._rtrns["net"] > 0).sum() / self.num_symbols,
+            1,
+        )
+
+    @property
+    def losses_pct(self) -> float:
+        """Percentage of instruments resulting in net losses."""
+        return round(
+            100 * (self._rtrns["net"] < 0).sum() / self.num_symbols,
+            1,
+        )
+
+    @property
+    def rtrn_net(self) -> float:
+        """Aggregated net return."""
+        return self.rtrns["net"].sum()
+
+    @property
+    def rtrn_gross(self) -> float:
+        """Aggregated gross return."""
+        return self.rtrns["gross"].sum()
+
+    @property
+    def rtrn_gross_pct(self) -> float:
+        """Aggregated gross return, as percentage."""
+        return round(self.rtrn_gross * 100, 1)
+
+    @property
+    def rtrn_net_pct(self) -> float:
+        """Aggregated net return, as percentage."""
+        return round(self.rtrn_net * 100, 1)
+
+    @property
+    def profitable(self) -> bool:
+        """Query if profitable in aggregate (on net basis).
+
+        NOTE: Only spread is considered within costs.
+        """
+        return self.rtrn_net > 0
+
+    def distributed_rtrns(self) -> bq.Figure:  # type: ignore[return-value]
+        """Plot distributed returns."""
+        from .charts import (  # noqa: PLC0415
+            distributed_rtrns as chart_distributed_rtrns,
+        )
+
+        return chart_distributed_rtrns(self.rtrns_pct.net)


### PR DESCRIPTION
## Summary
This PR introduces a new `positions` module that provides base classes for representing, analyzing, and visualizing financial positions. The module enables tracking of individual positions taken in financial instruments and aggregating results across multiple instruments.

## Key Changes

- **PositionBase**: A frozen dataclass representing a single position with:
  - OHLC price data tracking the position's lifecycle
  - Properties for calculating returns (gross and net of spread), profitability, duration, and price extrema
  - Support for chart analysis through inheritance from `CaseBase` and `CaseSupportsChartAnaly`

- **PositionsBase**: A container for all positions in a single instrument over an analysis period with:
  - Aggregated metrics across all positions (total returns, profitability percentage)
  - Convenience properties for accessing position attributes in bulk (open/close dates, prices, returns)
  - HTML generation for position tooltips with color-coding based on profitability
  - Integration with chart analysis framework

- **ConsolidatedBase**: A summary class for consolidating position results across multiple instruments with:
  - Per-instrument return tracking and sorting
  - Aggregate statistics (total returns, percentage of profitable instruments)
  - Chart generation for distributed returns visualization

- **ChartPositionsBase**: An OHLC chart with position overlays showing:
  - Colored lines tracking each position (green for profitable, red for losses)
  - Scatter marks for position opens (circles) and closes (crosses)
  - Interactive tooltips with detailed position information

- **PositionsGuiBase**: An interactive GUI for displaying and analyzing positions with:
  - Integration with the existing GUI framework
  - Support for narrow and wide view modes
  - Customizable chart parameters

## Implementation Details

- Positions track both the mid-price and spread costs, allowing calculation of net returns
- The `line` property provides a special series representation with duplicate indices for session opens to capture both entry and session-end prices
- Profitability is determined on a net basis (accounting for spread costs)
- The module integrates with existing `market_analy` infrastructure (cases, charts, formatters, GUIs)
- All classes use type hints and frozen dataclasses where appropriate for immutability

https://claude.ai/code/session_01TnPAQhPW1RpEYuKuQFwqmY