### PR TITLE
Update dependencies-management skill

### DIFF
--- a/.agents/skills/dependencies-management/SKILL.md
+++ b/.agents/skills/dependencies-management/SKILL.md
@@ -14,8 +14,31 @@ Create a new branch (following the naming convention in @AGENTS.md).
 
 ### 2. Update the lock file and environment
 
+Update `uv`:
 ```bash
-uv self update
+uv self update --token $GITHUB_TOKEN
+```
+
+**IMPORTANT: updating `uv` MUST NOT be skipped.** If the above command fails (e.g. due to a GitHub API rate limit), try the following fallbacks in order until `uv --version` confirms the latest version is active on PATH:
+
+**Fallback 1 — official install script** (preferred; replaces PATH binary directly):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.local/bin/env  # refresh current shell session
+uv --version                 # verify PATH binary is now updated
+```
+
+**Fallback 2 — pip** (use only if `curl` is unavailable):
+
+```bash
+pip install --user --upgrade uv
+uv --version   # check if PATH binary was updated
+```
+
+Once `uv` is up to date, run:
+
+```bash
 uv lock --upgrade  # update the lock file
 uv export --format requirements-txt --no-emit-project --no-hashes --no-dev -o requirements.txt  # sync @requirements.txt with @uv.lock
 uv sync --inexact  # update environment to match @uv.lock
@@ -32,7 +55,18 @@ prompt: What is the latest release tag for this GitHub action?
 
 In each case update the version pin to any more recent release. **Preserve the existing pinning style**, so if the current pin is a specific version such as `@v3.0.1`, update to the full latest version string, whilst if it's a major-version tag such as `@v4`, update to any new major-version tag (if the project no longer publishes a major-version tag then switch to the full semver).
 
-### 4. Test
+### 4. Update pre-commit hook versions
+
+For each `repo:` entry in `.pre-commit-config.yaml`, retrieve the latest release tag by fetching the releases page with WebFetch:
+
+```
+url:    https://github.com/<owner>/<repo>/releases/latest
+prompt: What is the latest release tag for this pre-commit hook?
+```
+
+In each case update the `rev:` pin to any more recent release. **Preserve the existing pinning style**, so if the current pin is a specific version such as `v6.0.0`, update to the full latest version string, whilst if it's a major-version tag such as `@v4`, update to any new major-version tag (if the project no longer publishes a major-version tag then switch to the full semver).
+
+### 5. Test
 
 Run the test suite:
 ```bash
@@ -40,10 +74,10 @@ uv run pytest -v
 ```
 
 **Interpret local test results:**
-- All tests pass and no raised warning is fixable (see *Fixable warnings* section below) → go to step 6 to raise PR.
-- Any test failure or a fixable warning raised → proceed to step 5 to fix.
+- All tests pass and no raised warning is fixable (see *Fixable warnings* section below) → go to step 7 to raise PR.
+- Any test failure or a fixable warning raised → proceed to step 6 to fix.
 
-### 5. Fix
+### 6. Fix
 Any failing tests and fixable warnings will likely have their origin in changes to the dependencies. To provide support for the latest dependencies MAKE REVISIONS to the code base to fix:
 - code causing tests to fail.
 - all fixable warnings (see *Fixable warnings* section below).
@@ -62,7 +96,7 @@ IMPORTANT: in this step you should not run the full test suite, rather validate 
 pytest tests/test_module.py::test_name
 ```
 
-### 6. Raise PR
+### 7. Raise PR
 
 Once local tests pass, commit all changes to the branch and raise a PR.
 
@@ -70,24 +104,24 @@ Once local tests pass, commit all changes to the branch and raise a PR.
   - `<MM>` should be replaced with the first three letters of the current month, the first of which should be capitalized.
   - `<DD>` should be replaced with the current day of the month as represented by two digits.
   Example title: `Update Dependencies Apr 07 (auto)`
-- **label**: Add the 'dependencies' label to the PR via `mcp__github__update_pull_request`.
+- **label**: Add the 'dependencies' label to the PR.
 - otherwise comply with the package's 'create-pr' skill.
 
-### 7. Subscribe to PR activity
+### 8. Subscribe to PR activity
 
 By raising the PR a GitHub CI workflow will be triggered. Subscribe to the raised PR's activity.
 
-Proceed to step 8 when you receive an event indicating that the triggered workflow has completed.
+Proceed to step 9 when you receive an event indicating that the triggered workflow has completed.
 
-### 8. Inspect CI results
+### 9. Inspect CI results
 
 The CI workflow will have run the full test suite against a matrix of OS and Python versions. Use `mcp__github__pull_request_read` with the `get_check_runs` method to read check statuses for all matrix jobs.
 
 **Interpret CI test results:**
-- All checks green → proceed to step 11.
-- Any check red → proceed to step 9.
+- All checks green → proceed to step 12.
+- Any check red → proceed to step 10.
 
-### 9. Fix tests for specific OS/Python configuration
+### 10. Fix tests for specific OS/Python configuration
 
 Use the information read from `get_check_runs` to identify any OS/python version configurations for which the test suite has failed.
 
@@ -104,18 +138,18 @@ Run the test suite to identify failing tests. For example:
 uv run --isolated --python 3.11 python pytest --ignore=tests/test_yahoo.py -v
 ```
 
-Then find fixes for the failing tests by following step 5.
+Then find fixes for the failing tests by following step 6.
 
-Finally commit the necessary changes to your *original* branch (to which previous commits were made). This will trigger the CI on the PR re-run. Return to step 8 (inspect CI results).
+Finally commit the necessary changes to your *original* branch (to which previous commits were made). This will trigger the CI on the PR re-run. Return to step 9 (inspect CI results).
 
-### 10. Fallback: raise an issue
+### 11. Fallback: raise an issue
 
 ONLY if any test failures cannot be resolved, raise an issue that references the PR and details:
 - the failing tests
 - any fixes already attempted
 - any suggested next steps.
 
-### 11. Tidy up
+### 12. Tidy up
 
 Perform the following 'tidy up' actions:
 - Call `mcp__github__unsubscribe_pr_activity` to unscubscribe from the PR activity.


### PR DESCRIPTION
Generated by Claude.

Update the `dependencies-management` skill:
- **Step 2**: Replace the simple `uv self update` command with the expanded version that uses `--token $GITHUB_TOKEN`, marks the update as mandatory, and provides two ordered fallback methods (official install script; pip) in case the primary command fails.
- **Step 4 (new)**: Add a step to update pre-commit hook versions by fetching the latest release tag for each `repo:` entry in `.pre-commit-config.yaml`. Subsequent steps renumbered and all internal step cross-references updated accordingly.
- **Raise PR step** (step 7): Remove the instruction to use `mcp__github__update_pull_request` specifically when adding the 'dependencies' label.