### PR TITLE
Fix selector box on GuiOHLCCaseBase guis

### DIFF
--- a/src/market_analy/guis.py
+++ b/src/market_analy/guis.py
@@ -2104,13 +2104,16 @@ class GuiOHLCCaseBase(GuiOHLC):
 
     @property
     def _gui_box_contents(self) -> list[w.Widget]:
-        return [
-            self._icon_row_top,
+        contents = [self._icon_row_top]
+        if self._selector_boxes is not None:
+            contents += [self._selector_boxes]
+        contents += [
             self.chart.figure,
             self.date_slider,
             self._controls_container,
             self.html_output,
         ]
+        return contents
 
     def _create_date_slider(self, **kwargs):
         ds = super()._create_date_slider(**kwargs)


### PR DESCRIPTION
Fixes `GuiOHLCCaseBase` to include the drawdown selector (held in `_selector_boxes`) if a subclass has `_HAS_DRAWDOWN = True`.

The fix conditionally includes `self._selector_boxes` in the layout, mirroring `BasePrice._gui_box_contents`, placing it directly after the top icon row (consistent with the GUI produced by `Analysis.plot`).

`TrendsGuiBase` is unaffected: it sets both `_HAS_INTERVAL_SELECTOR = False` and `_HAS_DRAWDOWN = False`, so `_selector_boxes` is `None` and the `is not None` guard leaves its layout unchanged.

---
Generated with Claude, manually revised.
_Generated by [Claude Code](https://claude.ai/code/session_01GYtY8MgwTrCshQT44ZkdaM)_