### PR TITLE
Use d3 "~f" format for price y-axis tick labels

### DIFF
--- a/src/market_analy/charts.py
+++ b/src/market_analy/charts.py
@@ -1842,10 +1842,7 @@ class BasePrice(BaseSubsetDD):
         #    label: 'Date'
         # For y
         #    "~f" formats ticks in fixed-point notation with insignificant
-        #        trailing zeros trimmed. This keeps labels readable across
-        #        the range of prices encountered, for example showing "150"
-        #        rather than "150.000" and "0.85" rather than "0.850000",
-        #        without having to tailor the precision to the y value.
+        #        trailing zeros trimmed.
         #    label_offset': '3em'
         #    label: 'Price'
         dflt_axes_kwargs = {"x": {"num_ticks": 6}, "y": {"tick_format": "~f"}}

--- a/src/market_analy/charts.py
+++ b/src/market_analy/charts.py
@@ -1841,13 +1841,14 @@ class BasePrice(BaseSubsetDD):
         #    label_offset': '2.5em'
         #    label: 'Date'
         # For y
-        #    tick_format may not be appropriate for all, i.e. might be
-        #        better to set according to y value, i.e. if under 1 then
-        #        maybe only 4 significant places?
+        #    "~f" formats ticks in fixed-point notation with insignificant
+        #        trailing zeros trimmed. This keeps labels readable across
+        #        the range of prices encountered, for example showing "150"
+        #        rather than "150.000" and "0.85" rather than "0.850000",
+        #        without having to tailor the precision to the y value.
         #    label_offset': '3em'
         #    label: 'Price'
-        # TODO: change tick_format to "~f"
-        dflt_axes_kwargs = {"x": {"num_ticks": 6}, "y": {"tick_format": ".6r"}}
+        dflt_axes_kwargs = {"x": {"num_ticks": 6}, "y": {"tick_format": "~f"}}
         axes_kwargs = self._add_axes_kwargs(dflt_axes_kwargs, axes_kwargs)
         return super()._axes_kwargs(axes_kwargs, **general_kwargs)
 

--- a/src/market_analy/utils/bq_utils.py
+++ b/src/market_analy/utils/bq_utils.py
@@ -658,13 +658,16 @@ class Crosshair(HasTraits):
 
     @property
     def _y_tick_format_python_format(self):
-        # Convert the d3-format y-axis tick format to an equivalent Python
-        # format specifier for `str.format`. Python's format mini-language
-        # understands neither d3-format's "~" flag (trim insignificant
-        # trailing zeros) nor its "r" type (round to significant digits).
-        # Both are mapped to Python's "g" type, which itself trims trailing
-        # zeros, so the crosshair label mirrors the axis ticks as closely as
-        # the two format languages allow.
+        """Convert d3-format to equivalent Python format spec.
+
+        Provides for crosshair label mirrors formatted with `str.format` to
+        align with axis ticks (formatted as d3) as closely as the two
+        format languages allow.
+        """
+        # Python's format mini-language understands neither d3-format's
+        # "~" flag (trim insignificant trailing zeros) nor its "r" type
+        # (round to significant digits). Map both to Python's "g" type,
+        # which trims trailing zeros.
         fmt = self._y_tick_format
         if "~" in fmt:
             fmt = fmt.replace("~", "").replace("f", "g")

--- a/src/market_analy/utils/bq_utils.py
+++ b/src/market_analy/utils/bq_utils.py
@@ -658,7 +658,17 @@ class Crosshair(HasTraits):
 
     @property
     def _y_tick_format_python_format(self):
-        return self._y_tick_format.replace("r", "g")
+        # Convert the d3-format y-axis tick format to an equivalent Python
+        # format specifier for `str.format`. Python's format mini-language
+        # understands neither d3-format's "~" flag (trim insignificant
+        # trailing zeros) nor its "r" type (round to significant digits).
+        # Both are mapped to Python's "g" type, which itself trims trailing
+        # zeros, so the crosshair label mirrors the axis ticks as closely as
+        # the two format languages allow.
+        fmt = self._y_tick_format
+        if "~" in fmt:
+            fmt = fmt.replace("~", "").replace("f", "g")
+        return fmt.replace("r", "g")
 
     def _get_x_center(self, x: list):
         """Mid-point of x axis.


### PR DESCRIPTION
Improve formatting of y-axis ticks - changes from `".6r"` to `"~f"`

 The d3-format `"~f"` presents prices in fixed-point notation with insignificant trailing zeros trimmed, keeping tick labels readable across the range of prices encountered (e.g. `"150"` rather than `"150.000"`, `"0.85"` rather than `"0.850000"`) without having to tailor the precision to the y value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Fully manually reviewed and doc revisions made.
https://claude.ai/code/session_012whhbWckaqugfPhvFafZ3s

---
_Generated by [Claude Code](https://claude.ai/code/session_012whhbWckaqugfPhvFafZ3s)_