### PR TITLE
Fix drawdown not redisplaying after tick interval change

### DIFF
--- a/src/market_analy/guis.py
+++ b/src/market_analy/guis.py
@@ -1511,7 +1511,14 @@ class BasePrice(BaseVariableDates):
         self._clear_user_activity()
         self._update_chart(data, data2, prices, reset_slider=True, visible_x_ticks=vxts)
         if self._HAS_DRAWDOWN:
-            self._drawdown_selector.set_value_unobserved("ATH")
+            # The new drawdown data always represents the all-time high, hence
+            # reset a shown drawdown to "ATH". A hidden drawdown (selector value
+            # False) must stay hidden though, otherwise the selector value would
+            # be inconsistent with the chart and re-selecting a drawdown period
+            # would fail to re-show the drawdown (the handler only shows the y2
+            # axis when the prior selection was a hidden state). See issue #246.
+            value = "ATH" if self._drawdown_selector.value else False
+            self._drawdown_selector.set_value_unobserved(value)
 
     def _reset_chart(self):
         """Reset initial chart."""

--- a/tests/test_guis.py
+++ b/tests/test_guis.py
@@ -3,6 +3,7 @@
 import bqplot as bq
 import pandas as pd
 import pytest
+from market_prices.intervals import to_ptinterval
 
 from market_analy import analysis, charts
 
@@ -223,3 +224,58 @@ class TestGuiMultLineSubplots:
         assert list(pane.data.columns) == comp.symbols
         expected = gui.prices.xs("volume", axis=1, level=-1)
         assert (pane.data.values == expected.values).all()
+
+
+class TestDrawdownIntervalInteraction:
+    """Tests for the drawdown selector / tick interval interaction.
+
+    Verifies that the drawdown plot can be hidden and redisplayed after a
+    change to the tick interval (regression test for issue #246).
+    """
+
+    @pytest.fixture
+    def analy(self, prices_analysis) -> analysis.Analysis:
+        return analysis.Analysis(prices_analysis)
+
+    @pytest.fixture
+    def gui(self, analy):
+        """`GuiLine` with the drawdown shown and a daily tick interval."""
+        gui = analy.plot(start="2022-01-01", end="2022-12-31", display=False)
+        assert gui._drawdown_selector.value == "ATH"
+        assert gui.chart.mark_y2.visible
+        return gui
+
+    def test_hide_show_without_interval_change(self, gui):
+        """Drawdown can be hidden and redisplayed (no interval change)."""
+        gui._drawdown_selector.value = False
+        assert not gui.chart.mark_y2.visible
+        gui._drawdown_selector.value = 10
+        assert gui.chart.mark_y2.visible
+
+    def test_interval_change_preserves_shown_drawdown(self, gui):
+        """A shown drawdown remains shown, as 'ATH', after interval change."""
+        gui._change_tick_interval(to_ptinterval("1D"), to_ptinterval("5D"))
+        assert gui._drawdown_selector.value == "ATH"
+        assert gui.chart.mark_y2.visible
+
+    def test_interval_change_preserves_hidden_drawdown(self, gui):
+        """A hidden drawdown stays hidden after interval change.
+
+        The selector value must remain consistent with the (hidden) chart
+        state, i.e. it should not be reset to 'ATH'.
+        """
+        gui._drawdown_selector.value = False
+        gui._change_tick_interval(to_ptinterval("1D"), to_ptinterval("5D"))
+        assert gui._drawdown_selector.value is False
+        assert not gui.chart.mark_y2.visible
+
+    def test_redisplay_drawdown_after_interval_change(self, gui):
+        """Drawdown reappears when reselected after an interval change.
+
+        Replicates the scenario reported in issue #246: hide the drawdown,
+        change the tick interval, then reselect a drawdown period.
+        """
+        gui._drawdown_selector.value = False
+        gui._change_tick_interval(to_ptinterval("1D"), to_ptinterval("5D"))
+        gui._drawdown_selector.value = 10
+        assert gui.chart.mark_y2.visible


### PR DESCRIPTION
Generated by Claude.

Closes #246.

## Problem

If the drawdown plot was turned off (with the 'x' button), the tick interval was then changed, and the user then tried to redisplay the drawdown by selecting a drawdown period button, the drawdown would not reappear.

The bug only manifested when the tick interval was changed while the drawdown was hidden — hiding/redisplaying without an interval change worked, and a displayed drawdown continued to show after an interval change.

## Cause

On a tick interval change, `BasePrice._change_tick_interval` unconditionally reset the drawdown selector value to `"ATH"` (unobserved), even when the drawdown was hidden and the chart's y2 axis left hidden. This left the selector value inconsistent with the chart state.

When the user subsequently selected a drawdown period, `_drawdown_selector_handler` read `old == "ATH"` (truthy), so the guard `if not old: self.chart.show_y2()` was skipped and the y2 axis was never re-shown.

## Fix

The selector value is now only reset to `"ATH"` when the drawdown is currently shown. A hidden drawdown retains its `False` selector value, keeping the selector consistent with the chart so that a subsequent period selection correctly transitions from the hidden state and re-shows the y2 axis.

## Tests

Adds `TestDrawdownIntervalInteraction` to `tests/test_guis.py` covering:
- hide/redisplay without an interval change;
- a shown drawdown remaining shown (as `"ATH"`) after an interval change;
- a hidden drawdown staying hidden after an interval change;
- the reported scenario — hide, change interval, reselect a period — now redisplaying the drawdown.

The two scenario tests fail against the original code and pass with the fix. Full `tests/test_guis.py` (22) and `tests/test_analysis.py` (50) suites pass; `ruff check`/`ruff format` are clean and `mypy` reports no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014MDEPAFiQPq7dJcZQrfCG2)_