### PR TITLE
Disambiguate intra-bar moves in max_advance / max_decline

### DIFF
--- a/src/market_analy/analysis.py
+++ b/src/market_analy/analysis.py
@@ -243,14 +243,18 @@ def max_advance(prices: pd.DataFrame, label: Any = None) -> pd.DataFrame:
     """Return maximum percentage advance.
 
     The advance is evaluated as the greatest percentage rise from a low
-    to a subsequent high. Where the low and high being considered fall
-    on the same bar the intra-bar order of the two is inferred from the
-    bar direction; an advance is only recognised within a single bar if
-    the bar closed at or above the open (the low is assumed to have been
-    registered before the high). On a bar that closed below the open the
-    high is assumed to have been registered before the low, such that the
-    bar cannot, of itself, represent an advance (although the bar's low
-    can still represent the start of an advance to a later bar's high).
+    to a subsequent high.
+
+    A note on single-bar advances: Advances from the low to the high of a
+    single DOWN bar are ignored (a down bar is defined as a bar where the
+    bar close is lower than the bar open). In this case it is assumed that
+    the bar high was registered before the bar low and hence there was no
+    'low-to-high' advance. On the contrary, if the advance from the low to
+    the high of single UP bar is the greatest 'low to subsequent high' in
+    `prices` then this will be considered as the max advance (for an up bar
+    the bar low is assumed to have been registered before the bar high, and
+    hence the bar low-to-high is considered to represent a genuine
+    advance).
 
     Parameters
     ----------
@@ -300,14 +304,18 @@ def max_decline(prices: pd.DataFrame, label: Any = None) -> pd.DataFrame:
     """Return maximum percentage decline.
 
     The decline is evaluated as the greatest percentage fall from a high
-    to a subsequent low. Where the high and low being considered fall on
-    the same bar the intra-bar order of the two is inferred from the bar
-    direction; a decline is only recognised within a single bar if the
-    bar closed below the open (the high is assumed to have been
-    registered before the low). On a bar that closed at or above the open
-    the low is assumed to have been registered before the high, such that
-    the bar cannot, of itself, represent a decline (although the bar's
-    high can still represent the start of a decline to a later bar's low).
+    to a subsequent low.
+
+    A note on single-bar declines: Declines from the high to the low of a
+    single UP bar are ignored (an up bar is defined as a bar where the bar
+    close is higher than or equal to the bar open). In this case it is
+    assumed that the bar low was registered before the bar high and hence
+    there was no 'high-to-low' decline. On the contrary, if the decline
+    from the high to the low of single DOWN bar is the greatest 'high to
+    subsequent low' in `prices` then this will be considered as the max
+    decline (for a down bar the bar high is assumed to have been registered
+    before the bar low, and hence the bar high-to-low is considered to
+    represent a genuine decline).
 
     Parameters
     ----------

--- a/src/market_analy/analysis.py
+++ b/src/market_analy/analysis.py
@@ -242,31 +242,54 @@ def _add_duration_columns(d: dict, start: pd.Timestamp, end: pd.Timestamp) -> di
 def max_advance(prices: pd.DataFrame, label: Any = None) -> pd.DataFrame:
     """Return maximum percentage advance.
 
+    The advance is evaluated as the greatest percentage rise from a low
+    to a subsequent high. Where the low and high being considered fall
+    on the same bar the intra-bar order of the two is inferred from the
+    bar direction; an advance is only recognised within a single bar if
+    the bar closed at or above the open (the low is assumed to have been
+    registered before the high). On a bar that closed below the open the
+    high is assumed to have been registered before the low, such that the
+    bar cannot, of itself, represent an advance (although the bar's low
+    can still represent the start of an advance to a later bar's high).
+
     Parameters
     ----------
     prices
-        Price data covering period within which to return maximum advance.
+        Price data covering period within which to return maximum
+        advance. Must include columns "open", "high", "low" and "close".
 
     label
         Value to assign to index label. Default 0.
     """
-    df = prices.loc[:, ["high", "low"]]
+    df = prices.loc[:, ["open", "high", "low", "close"]]
 
-    df["max_adv"] = df["high"] / df["low"].cummin() - 1
+    # On an 'up' bar (close >= open) the low is assumed to precede the
+    # high, such that the bar's own low can pair with its own high. On a
+    # 'down' bar the high precedes the low, so the high can only be paired
+    # with the lowest low registered up to, but excluding, the same bar.
+    low_cummin = df["low"].cummin()
+    is_up = df["close"] >= df["open"]
+    trough = low_cummin.where(is_up, low_cummin.shift(1))
+
+    df["max_adv"] = df["high"] / trough - 1
     max_adv = df["max_adv"].max()
 
     end = df[df["max_adv"] == max_adv]
     end = end.index[-1]  # if >1 max adv of same value, the most recent
 
+    high = df.loc[end, "high"]
     df = df.loc[:end]
-    start = df[df["low"] == df["low"].min()]
+    if not is_up.loc[end]:
+        # a 'down' end bar cannot be the start of its own advance
+        df = df.iloc[:-1]
+    start = df[df["low"] == trough.loc[end]]
     start = start.index[-1]  # if >1 lows of same value, the most recent
 
     d = {
         "start": [start],
         "low": [df.loc[start, "low"]],
         "end": [end],
-        "high": [df.loc[end, "high"]],
+        "high": [high],
         "pct_chg": [max_adv],
     }
     d = _add_duration_columns(d, start, end)
@@ -276,31 +299,54 @@ def max_advance(prices: pd.DataFrame, label: Any = None) -> pd.DataFrame:
 def max_decline(prices: pd.DataFrame, label: Any = None) -> pd.DataFrame:
     """Return maximum percentage decline.
 
+    The decline is evaluated as the greatest percentage fall from a high
+    to a subsequent low. Where the high and low being considered fall on
+    the same bar the intra-bar order of the two is inferred from the bar
+    direction; a decline is only recognised within a single bar if the
+    bar closed below the open (the high is assumed to have been
+    registered before the low). On a bar that closed at or above the open
+    the low is assumed to have been registered before the high, such that
+    the bar cannot, of itself, represent a decline (although the bar's
+    high can still represent the start of a decline to a later bar's low).
+
     Parameters
     ----------
     prices
-        Price data covering period within which to return maximum decline.
+        Price data covering period within which to return maximum
+        decline. Must include columns "open", "high", "low" and "close".
 
     label
         Value to assign to index label. Default 0.
     """
-    px = prices.loc[:, ["high", "low"]]
+    px = prices.loc[:, ["open", "high", "low", "close"]]
 
-    px["max_dec"] = px["low"] / px["high"].cummax() - 1
+    # On a 'down' bar (close < open) the high is assumed to precede the
+    # low, such that the bar's own high can pair with its own low. On an
+    # 'up' bar the low precedes the high, so the low can only be paired
+    # with the highest high registered up to, but excluding, the same bar.
+    high_cummax = px["high"].cummax()
+    is_down = px["close"] < px["open"]
+    peak = high_cummax.where(is_down, high_cummax.shift(1))
+
+    px["max_dec"] = px["low"] / peak - 1
     max_dec = px["max_dec"].min()
 
     end = px[px["max_dec"] == max_dec]
     end = end.index[-1]  # if >1 max dec of same value, the most recent
 
+    low = px.loc[end, "low"]
     px = px.loc[:end]
-    start = px[px["high"] == px["high"].max()]
+    if not is_down.loc[end]:
+        # an 'up' end bar cannot be the start of its own decline
+        px = px.iloc[:-1]
+    start = px[px["high"] == peak.loc[end]]
     start = start.index[-1]  # if >1 highs of same value, the most recent
 
     d = {
         "start": [start],
         "high": [px.loc[start, "high"]],
         "end": [end],
-        "low": [px.loc[end, "low"]],
+        "low": [low],
         "pct_chg": [max_dec],
     }
     d = _add_duration_columns(d, start, end)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -212,6 +212,56 @@ def test_max_advance_and_max_decline():
     assert rtrn.loc[("max_dec", "minutes")] == 4
 
 
+def test_max_advance_intrabar_disambiguation():
+    """Verify a 'down' bar's range is not misread as an advance.
+
+    The middle bar closes below its open (a 'down' bar) and has the
+    widest low-to-high range. Without disambiguation that range would be
+    reported as the maximum advance (low -> high on the same bar). As the
+    high is assumed to have been registered before the low, the advance
+    should instead run from the first bar's low to the middle bar's high.
+    """
+    opens = [100, 120, 110]
+    closes = [101, 100, 112]  # bar1 is a 'down' bar (close < open)
+    highs = [102, 130, 113]
+    lows = [99, 90, 109]
+    index = pd.date_range("2023-01-01", freq="D", periods=len(opens))
+    df = pd.DataFrame(dict(open=opens, high=highs, low=lows, close=closes), index=index)
+
+    rtrn = analysis.max_advance(df, label="max_adv")
+    assert rtrn.loc[("max_adv", "start")] == index[0]
+    assert rtrn.loc[("max_adv", "low")] == lows[0]
+    assert rtrn.loc[("max_adv", "end")] == index[1]
+    assert rtrn.loc[("max_adv", "high")] == highs[1]
+    assert round(rtrn.loc[("max_adv", "pct_chg")], 3) == round(130 / 99 - 1, 3)
+    assert rtrn.loc[("max_adv", "days")] == 1
+
+
+def test_max_decline_intrabar_disambiguation():
+    """Verify an 'up' bar's range is not misread as a decline.
+
+    The middle bar closes at or above its open (an 'up' bar) and has the
+    widest high-to-low range. Without disambiguation that range would be
+    reported as the maximum decline (high -> low on the same bar). As the
+    low is assumed to have been registered before the high, the decline
+    should instead run from the first bar's high to the middle bar's low.
+    """
+    opens = [100, 80, 90]
+    closes = [99, 100, 88]  # bar1 is an 'up' bar (close >= open)
+    highs = [101, 110, 91]
+    lows = [98, 70, 87]
+    index = pd.date_range("2023-01-01", freq="D", periods=len(opens))
+    df = pd.DataFrame(dict(open=opens, high=highs, low=lows, close=closes), index=index)
+
+    rtrn = analysis.max_decline(df, label="max_dec")
+    assert rtrn.loc[("max_dec", "start")] == index[0]
+    assert rtrn.loc[("max_dec", "high")] == highs[0]
+    assert rtrn.loc[("max_dec", "end")] == index[1]
+    assert rtrn.loc[("max_dec", "low")] == lows[1]
+    assert round(rtrn.loc[("max_dec", "pct_chg")], 3) == round(70 / 101 - 1, 3)
+    assert rtrn.loc[("max_dec", "days")] == 1
+
+
 def test_style_df():
     opens = closes = [100, 110, 105]
     highs = [v + 1 for v in opens]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -222,12 +222,19 @@ def test_max_advance_intrabar_disambiguation():
     should instead run from the first bar's low to the middle bar's high.
     """
     opens = [100, 120, 110]
-    closes = [101, 100, 112]  # bar1 is a 'down' bar (close < open)
+    closes = [101, 100, 112]
     highs = [102, 130, 113]
     lows = [99, 90, 109]
     index = pd.date_range("2023-01-01", freq="D", periods=len(opens))
     df = pd.DataFrame(dict(open=opens, high=highs, low=lows, close=closes), index=index)
 
+    # verify assumed conditions
+    assert df.iloc[1].close < df.iloc[1].open  # bar1 is a `down` bar
+    bar1_adv = df.iloc[1].high / df.iloc[1].low - 1
+    bar0_1_adv = df.iloc[1].high / df.iloc[0].low - 1
+    assert bar1_adv > bar0_1_adv
+
+    # verify expected
     rtrn = analysis.max_advance(df, label="max_adv")
     assert rtrn.loc[("max_adv", "start")] == index[0]
     assert rtrn.loc[("max_adv", "low")] == lows[0]
@@ -247,12 +254,19 @@ def test_max_decline_intrabar_disambiguation():
     should instead run from the first bar's high to the middle bar's low.
     """
     opens = [100, 80, 90]
-    closes = [99, 100, 88]  # bar1 is an 'up' bar (close >= open)
+    closes = [99, 100, 88]
     highs = [101, 110, 91]
     lows = [98, 70, 87]
     index = pd.date_range("2023-01-01", freq="D", periods=len(opens))
     df = pd.DataFrame(dict(open=opens, high=highs, low=lows, close=closes), index=index)
 
+    # verify assumed conditions
+    assert df.iloc[1].close > df.iloc[1].open  # bar1 is an `up` bar
+    bar1_dec = df.iloc[1].low / df.iloc[1].high - 1
+    bar0_1_dec = df.iloc[1].low / df.iloc[0].high - 1
+    assert abs(bar1_dec) > abs(bar0_1_dec)
+
+    # verify expected
     rtrn = analysis.max_decline(df, label="max_dec")
     assert rtrn.loc[("max_dec", "start")] == index[0]
     assert rtrn.loc[("max_dec", "high")] == highs[0]


### PR DESCRIPTION
Closes #1.

## Problem

`max_advance` and `max_decline` (in `src/market_analy/analysis.py`) inferred the maximum percentage change purely from each bar's high and low, implicitly assuming that within any single bar the low was always registered before the high.

This meant a single **down** bar (a wide-range bar that closed below its open) could be misread as the maximum *advance* — the code assumed price travelled `low -> high` within the bar when, in reality, the high preceded the low. The symmetric problem affected `max_decline`: a single **up** bar could be misread as the maximum *decline* (`high -> low`).

## Fix

Disambiguate the intra-bar order of the high and low from the bar's direction, as proposed in the issue:

- **Up bar** (`close >= open`): the low is assumed to have been registered *before* the high.
- **Down bar** (`close < open`): the high is assumed to have been registered *before* the low.

Consequences:

- A bar can only represent an advance *within itself* when it is an up bar, and a decline within itself only when it is a down bar.
- A bar's low/high is still available to pair with the extremes of *other* bars (inter-bar moves are unaffected — the low of an earlier bar always precedes the high of a later bar).

Implementation detail: for `max_advance`, the lowest low available to pair with a bar's high is the running min including the current bar on up bars, but excluding it on down bars (`cummin().shift(1)`). `max_decline` is the mirror image using the running max of highs.

## Tests

- Existing `test_max_advance_and_max_decline` continues to pass unchanged.
- Added `test_max_advance_intrabar_disambiguation` and `test_max_decline_intrabar_disambiguation`, each constructing a wide-range bar in the "wrong" direction and asserting the change is measured across bars rather than within the misleading bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code). Fully manually reviewed.

https://claude.ai/code/session_01Lv7mb1yrXN6TmEefXjJ6xS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lv7mb1yrXN6TmEefXjJ6xS)_