### PR TITLE
Provide for `SyncedTooltip` to display value only

### DIFF
--- a/src/market_analy/charts.py
+++ b/src/market_analy/charts.py
@@ -1796,7 +1796,10 @@ class SyncedTooltip:
 
     @property
     def _synced_tooltip_prefix(self) -> str:
-        """Label prefixing the synced-tooltip value."""
+        """Label prefixing the synced-tooltip value.
+
+        To omit a prefix host should override to return an empty string.
+        """
         return self.title or "Value"
 
     def _synced_tooltip_fields(self, x: pd.Timestamp) -> list[tuple[str, str]] | None:
@@ -1889,7 +1892,9 @@ class SyncedTooltip:
         if not fields or anchor is None:
             self.hide_synced_tooltip()
             return
-        text = " | ".join(f"{label}: {value}" for label, value in fields)
+        text = " | ".join(
+            (f"{label}: {value}" if label else value) for label, value in fields
+        )
         color = self._tooltip_color(x)
         cross_color = self._synced_tooltip_cross_color(x)
 

--- a/src/market_analy/charts.py
+++ b/src/market_analy/charts.py
@@ -1755,8 +1755,8 @@ class SyncedTooltip:
             y=[],
             scales=scales,
             marker="crosshair",
-            stroke_width=2.5,
-            default_size=120,
+            stroke_width=2,
+            default_size=60,
             visible=False,
         )
         self._synced_tooltip_mark = bq.Label(


### PR DESCRIPTION
Provides for `SyncedTooltip` to display text as value only if the prefix is defined as an empty string.

Also reduces size of the `SyncedTooltip` 'x' mark by half.